### PR TITLE
ダッシュボードに月切り替え機能を追加 (issue #8)

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -1,6 +1,8 @@
 import Link from "next/link";
 import { redirect } from "next/navigation";
+import { Suspense } from "react";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
+import MonthNav from "@/components/MonthNav";
 
 function formatAmount(amount) {
   return new Intl.NumberFormat('ja-JP').format(amount);
@@ -11,22 +13,28 @@ function formatDate(dateStr) {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
-export default async function Home() {
+function currentYYYYMM() {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export default async function Home({ searchParams }) {
   const supabase = await createSupabaseServerClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/login');
 
-  const now = new Date();
-  const year = now.getFullYear();
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const fromDate = `${year}-${month}-01`;
-  const toDate = now.getMonth() === 11
-    ? `${year + 1}-01-01`
-    : `${year}-${String(now.getMonth() + 2).padStart(2, '0')}-01`;
+  const params = await searchParams;
+  const month = (typeof params?.month === 'string' && /^\d{4}-\d{2}$/.test(params.month))
+    ? params.month
+    : currentYYYYMM();
+
+  const [year, monthNum] = month.split('-').map(Number);
+  const fromDate = `${year}-${String(monthNum).padStart(2, '0')}-01`;
+  const nextMonth = monthNum === 12 ? `${year + 1}-01-01` : `${year}-${String(monthNum + 1).padStart(2, '0')}-01`;
 
   const [incomeRes, expenseRes, recentIncomeRes, recentExpenseRes] = await Promise.all([
-    supabase.from('income').select('amount').gte('entry_date', fromDate).lt('entry_date', toDate),
-    supabase.from('expense').select('amount').gte('entry_date', fromDate).lt('entry_date', toDate),
+    supabase.from('income').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonth),
+    supabase.from('expense').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonth),
     supabase.from('income').select('id, source, amount, entry_date').order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(5),
     supabase.from('expense').select('id, source, amount, entry_date').order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(5),
   ]);
@@ -40,8 +48,15 @@ export default async function Home() {
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-6 max-w-2xl mx-auto">
-      <h1 className="text-2xl font-bold mb-1">household hub</h1>
-      <p className="text-gray-400 text-sm mb-6">{year}年{Number(month)}月の収支</p>
+      <div className="flex items-center justify-between mb-1">
+        <h1 className="text-2xl font-bold">household hub</h1>
+      </div>
+
+      <div className="flex items-center justify-between mb-6">
+        <Suspense fallback={<div className="h-8" />}>
+          <MonthNav month={month} />
+        </Suspense>
+      </div>
 
       <div className="grid grid-cols-3 gap-3 mb-8">
         <div className="bg-gray-800 rounded-xl p-4">

--- a/src/components/MonthNav.tsx
+++ b/src/components/MonthNav.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+
+function addMonths(yyyyMM: string, delta: number): string {
+  const [y, m] = yyyyMM.split('-').map(Number);
+  const d = new Date(y, m - 1 + delta, 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+
+function monthOptions(): { value: string; label: string }[] {
+  const now = new Date();
+  const options: { value: string; label: string }[] = [];
+  for (let i = -12; i <= 3; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() + i, 1);
+    const value = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+    const label = `${d.getFullYear()}年${d.getMonth() + 1}月`;
+    options.push({ value, label });
+  }
+  return options;
+}
+
+type Props = { month: string };
+
+export default function MonthNav({ month }: Props) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const go = (m: string) => {
+    const params = new URLSearchParams(searchParams?.toString() ?? '');
+    params.set('month', m);
+    router.push(`/?${params.toString()}`);
+  };
+
+  const [year, monthNum] = month.split('-').map(Number);
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => go(addMonths(month, -1))}
+        className="p-1.5 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-300 transition-colors"
+        aria-label="前月"
+      >
+        ‹
+      </button>
+
+      <select
+        value={month}
+        onChange={(e) => go(e.target.value)}
+        className="bg-gray-800 text-white text-sm rounded-lg px-2 py-1 border border-gray-700 focus:outline-none focus:border-blue-500"
+      >
+        {monthOptions().map(({ value, label }) => (
+          <option key={value} value={value}>{label}</option>
+        ))}
+      </select>
+
+      <button
+        onClick={() => go(addMonths(month, 1))}
+        className="p-1.5 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-300 transition-colors"
+        aria-label="翌月"
+      >
+        ›
+      </button>
+
+      <span className="text-gray-400 text-sm hidden sm:inline">
+        {year}年{monthNum}月
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- ‹ / › ボタンで前月・翌月に切り替え
- セレクトボックスで直接月を選択（過去12ヶ月〜3ヶ月先）
- `?month=YYYY-MM` でURLに反映（ブックマーク・世帯メンバーとの共有対応）
- 不正な値・未指定は当月にフォールバック

## Test plan

- [ ] ‹/› ボタンで月が切り替わり、URLが更新されることを確認
- [ ] セレクトで任意の月を選択できることを確認
- [ ] ブラウザのURLを直接 `?month=2026-01` にして前月データが表示されることを確認
- [ ] 不正な値（`?month=abc`）で当月にフォールバックすることを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)