### PR TITLE
収入・支出一覧に月別フィルターを追加 (issue #13)

### DIFF
--- a/app/expense/page.tsx
+++ b/app/expense/page.tsx
@@ -1,18 +1,23 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import { readApiError } from '@/lib/ui/readApiError';
 import EditEntryModal from '@/components/EditEntryModal';
+import MonthNav from '@/components/MonthNav';
+import { parseMonth, monthToRange } from '@/lib/monthUtils';
 
 import type { Database } from '@/types/database.types';
 
 type ExpenseRow = Database['public']['Tables']['expense']['Row'];
 export default function ExpensePage() {
+  const searchParams = useSearchParams();
+  const month = parseMonth(searchParams?.get('month'));
+  const { from, to } = monthToRange(month);
+
   const [expenses, setExpenses] = useState<ExpenseRow[]>([]);
   const [filter, setFilter] = useState('');
-  const [from, setFrom] = useState('');
-  const [to, setTo] = useState('');
   const [loading, setLoading] = useState(true);
   const [errMsg, setErrMsg] = useState('');
   const [limit] = useState(50);
@@ -58,7 +63,7 @@ export default function ExpensePage() {
   useEffect(() => {
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [q, from, to, offset]);
+  }, [q, month, offset]);
 
   const handleSave = async (payload: { id?: number; source: string; amount: number; category: string; entry_date: string }) => {
     try {
@@ -117,17 +122,6 @@ export default function ExpensePage() {
     }, 0);
   }, [expenses]);
 
-  const setThisMonth = () => {
-    const d = new Date();
-    const y = d.getFullYear();
-    const m = d.getMonth();
-    const first = new Date(y, m, 1);
-    const last = new Date(y, m + 1, 0);
-    const fmt = (dt: Date) => dt.toISOString().slice(0, 10);
-    setFrom(fmt(first));
-    setTo(fmt(last));
-    setOffset(0);
-  };
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-4">
@@ -149,53 +143,21 @@ export default function ExpensePage() {
         </button>
       </div>
 
-      {/* フィルタ＆ヘッダ */}
-      <div className="mb-4 flex flex-col md:flex-row gap-3 items-start md:items-end">
-        <div className="flex flex-col">
-          <label className="text-sm mb-1">内容</label>
-          <input
-            type="text"
-            placeholder="内容を検索"
-            value={filter}
-            onChange={(e) => {
-              setFilter(e.target.value);
-              setOffset(0);
-            }}
-            className="p-2 border border-gray-600 rounded bg-gray-800 text-white placeholder-gray-400"
-          />
-        </div>
-        <div className="flex items-end gap-2">
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">From</label>
-            <input
-              type="date"
-              value={from}
-              onChange={(e) => {
-                setFrom(e.target.value);
-                setOffset(0);
-              }}
-              className="p-2 border border-gray-600 rounded bg-gray-800 text-white"
-            />
+      {/* 月切り替え＆フィルタ */}
+      <div className="mb-4 flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <MonthNav month={month} />
+          <div className="text-sm text-gray-400">
+            {totalCount.toLocaleString()} 件 / 合計 {total.toLocaleString()} 円
           </div>
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">To</label>
-            <input
-              type="date"
-              value={to}
-              onChange={(e) => {
-                setTo(e.target.value);
-                setOffset(0);
-              }}
-              className="p-2 border border-gray-600 rounded bg-gray-800 text-white"
-            />
-          </div>
-          <button type="button" onClick={setThisMonth} className="h-10 px-3 bg-gray-700 rounded hover:bg-gray-600">
-            今月
-          </button>
         </div>
-        <div className="ml-auto">
-          <div className="text-sm text-gray-400">件数: {totalCount.toLocaleString()} / 合計: {total.toLocaleString()} 円</div>
-        </div>
+        <input
+          type="text"
+          placeholder="内容を検索"
+          value={filter}
+          onChange={(e) => { setFilter(e.target.value); setOffset(0); }}
+          className="p-2 border border-gray-600 rounded bg-gray-800 text-white placeholder-gray-400 max-w-xs"
+        />
       </div>
 
       {/* 一覧 */}

--- a/app/income/page.tsx
+++ b/app/income/page.tsx
@@ -1,21 +1,26 @@
 'use client';
 
 import React, { useEffect, useMemo, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import EditEntryModal from '@/components/EditEntryModal';
+import MonthNav from '@/components/MonthNav';
 import { readApiError } from '@/lib/ui/readApiError';
+import { parseMonth, monthToRange } from '@/lib/monthUtils';
 
 // 型定義
 import type { Database } from '@/types/database.types';
 type IncomeRow = Database['public']['Tables']['income']['Row'];
 type IncomeInsert = Database['public']['Tables']['income']['Insert'];
 export default function IncomePage() {
+  const searchParams = useSearchParams();
+  const month = parseMonth(searchParams?.get('month'));
+  const { from, to } = monthToRange(month);
+
   const [amount, setAmount] = useState<string>('');
   const [source, setSource] = useState<string>('');
   const [incomes, setIncomes] = useState<IncomeRow[]>([]);
   const [filter, setFilter] = useState<string>('');
-  const [from, setFrom] = useState<string>(''); // YYYY-MM-DD
-  const [to, setTo] = useState<string>(''); // YYYY-MM-DD
   const [loading, setLoading] = useState<boolean>(true);
   const [errMsg, setErrMsg] = useState<string>('');
   const [editingId, setEditingId] = useState<number | null>(null);
@@ -61,7 +66,7 @@ export default function IncomePage() {
   useEffect(() => {
     void load();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [q, from, to, offset]);
+  }, [q, month, offset]);
 
   const resetForm = (): void => {
     setAmount('');
@@ -149,18 +154,6 @@ export default function IncomePage() {
     }, 0);
   }, [incomes]);
 
-  // 月範囲をワンタップで入れる補助（今月）
-  const setThisMonth = (): void => {
-    const d = new Date();
-    const y = d.getFullYear();
-    const m = d.getMonth();
-    const first = new Date(y, m, 1);
-    const last = new Date(y, m + 1, 0);
-    const fmt = (dt: Date) => dt.toISOString().slice(0, 10);
-    setFrom(fmt(first));
-    setTo(fmt(last));
-    setOffset(0);
-  };
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-4">
@@ -182,53 +175,21 @@ export default function IncomePage() {
         </button>
       </div>
 
-      {/* フィルタ＆ヘッダ */}
-      <div className="mb-4 flex flex-col md:flex-row gap-3 items-start md:items-end">
-        <div className="flex flex-col">
-          <label className="text-sm mb-1">内容</label>
-          <input
-            type="text"
-            placeholder="内容を検索"
-            value={filter}
-            onChange={(e) => {
-              setFilter(e.target.value);
-              setOffset(0);
-            }}
-            className="p-2 border border-gray-600 rounded bg-gray-800 text-white placeholder-gray-400"
-          />
-        </div>
-        <div className="flex items-end gap-2">
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">From</label>
-            <input
-              type="date"
-              value={from}
-              onChange={(e) => {
-                setFrom(e.target.value);
-                setOffset(0);
-              }}
-              className="p-2 border border-gray-600 rounded bg-gray-800 text-white"
-            />
+      {/* 月切り替え＆フィルタ */}
+      <div className="mb-4 flex flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <MonthNav month={month} />
+          <div className="text-sm text-gray-400">
+            {totalCount.toLocaleString()} 件 / 合計 {total.toLocaleString()} 円
           </div>
-          <div className="flex flex-col">
-            <label className="text-sm mb-1">To</label>
-            <input
-              type="date"
-              value={to}
-              onChange={(e) => {
-                setTo(e.target.value);
-                setOffset(0);
-              }}
-              className="p-2 border border-gray-600 rounded bg-gray-800 text-white"
-            />
-          </div>
-          <button type="button" onClick={setThisMonth} className="h-10 px-3 bg-gray-700 rounded hover:bg-gray-600">
-            今月
-          </button>
         </div>
-        <div className="ml-auto">
-          <div className="text-sm text-gray-400">件数: {totalCount.toLocaleString()} / 合計: {total.toLocaleString()} 円</div>
-        </div>
+        <input
+          type="text"
+          placeholder="内容を検索"
+          value={filter}
+          onChange={(e) => { setFilter(e.target.value); setOffset(0); }}
+          className="p-2 border border-gray-600 rounded bg-gray-800 text-white placeholder-gray-400 max-w-xs"
+        />
       </div>
 
       {/* 一覧 */}

--- a/app/page.js
+++ b/app/page.js
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import MonthNav from "@/components/MonthNav";
+import { parseMonth, monthToRange } from "@/lib/monthUtils";
 
 function formatAmount(amount) {
   return new Intl.NumberFormat('ja-JP').format(amount);
@@ -13,28 +14,21 @@ function formatDate(dateStr) {
   return `${d.getMonth() + 1}/${d.getDate()}`;
 }
 
-function currentYYYYMM() {
-  const now = new Date();
-  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-}
-
 export default async function Home({ searchParams }) {
   const supabase = await createSupabaseServerClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/login');
 
   const params = await searchParams;
-  const month = (typeof params?.month === 'string' && /^\d{4}-\d{2}$/.test(params.month))
-    ? params.month
-    : currentYYYYMM();
-
+  const month = parseMonth(params?.month);
+  const { from: fromDate, to: toDate } = monthToRange(month);
+  const nextMonth = new Date(toDate).getTime() + 86400000; // toDate の翌日
+  const nextMonthStr = new Date(nextMonth).toISOString().slice(0, 10);
   const [year, monthNum] = month.split('-').map(Number);
-  const fromDate = `${year}-${String(monthNum).padStart(2, '0')}-01`;
-  const nextMonth = monthNum === 12 ? `${year + 1}-01-01` : `${year}-${String(monthNum + 1).padStart(2, '0')}-01`;
 
   const [incomeRes, expenseRes, recentIncomeRes, recentExpenseRes] = await Promise.all([
-    supabase.from('income').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonth),
-    supabase.from('expense').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonth),
+    supabase.from('income').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
+    supabase.from('expense').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
     supabase.from('income').select('id, source, amount, entry_date').order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(5),
     supabase.from('expense').select('id, source, amount, entry_date').order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(5),
   ]);

--- a/src/components/MonthNav.tsx
+++ b/src/components/MonthNav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams, usePathname } from 'next/navigation';
 
 function addMonths(yyyyMM: string, delta: number): string {
   const [y, m] = yyyyMM.split('-').map(Number);
@@ -24,12 +24,13 @@ type Props = { month: string };
 
 export default function MonthNav({ month }: Props) {
   const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
 
   const go = (m: string) => {
     const params = new URLSearchParams(searchParams?.toString() ?? '');
     params.set('month', m);
-    router.push(`/?${params.toString()}`);
+    router.push(`${pathname}?${params.toString()}`);
   };
 
   const [year, monthNum] = month.split('-').map(Number);

--- a/src/lib/monthUtils.ts
+++ b/src/lib/monthUtils.ts
@@ -1,0 +1,19 @@
+export function currentYYYYMM(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+}
+
+export function parseMonth(raw: string | null | undefined): string {
+  if (raw && /^\d{4}-\d{2}$/.test(raw)) return raw;
+  return currentYYYYMM();
+}
+
+export function monthToRange(yyyyMM: string): { from: string; to: string } {
+  const [y, m] = yyyyMM.split('-').map(Number);
+  const lastDay = new Date(y, m, 0).getDate();
+  const mm = String(m).padStart(2, '0');
+  return {
+    from: `${y}-${mm}-01`,
+    to: `${y}-${mm}-${String(lastDay).padStart(2, '0')}`,
+  };
+}


### PR DESCRIPTION
## Summary

- 収入・支出ページに `MonthNav` を追加（‹/› ボタン + セレクト）
- `?month=YYYY-MM` で月をURLに反映、ダッシュボードと同じ操作感
- 既存の From/To 日付入力・今月ボタンを月ナビゲーターに置き換え
- `monthUtils.ts` に共通ロジックを集約しダッシュボードも統一

## Test plan

- [x] 収入・支出ページで月を切り替えるとデータが絞り込まれることを確認
- [x] URL の `?month=` がダッシュボードと同じ形式であることを確認
- [x] `npm run build` 通過

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)