### PR TITLE
カテゴリ別集計をダッシュボードに表示 (issue #7)

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -3,6 +3,7 @@ import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import MonthNav from "@/components/MonthNav";
+import CategoryPieChart from "@/components/CategoryPieChart";
 import { parseMonth, monthToRange } from "@/lib/monthUtils";
 
 function formatAmount(amount) {
@@ -26,11 +27,13 @@ export default async function Home({ searchParams }) {
   const nextMonthStr = new Date(nextMonth).toISOString().slice(0, 10);
   const [year, monthNum] = month.split('-').map(Number);
 
-  const [incomeRes, expenseRes, recentIncomeRes, recentExpenseRes] = await Promise.all([
+  const [incomeRes, expenseRes, recentIncomeRes, recentExpenseRes, incomeCatRes, expenseCatRes] = await Promise.all([
     supabase.from('income').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
     supabase.from('expense').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
     supabase.from('income').select('id, source, amount, entry_date').order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(5),
     supabase.from('expense').select('id, source, amount, entry_date').order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(5),
+    supabase.from('income').select('category, amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
+    supabase.from('expense').select('category, amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
   ]);
 
   const totalIncome = (incomeRes.data ?? []).reduce((sum, r) => sum + Number(r.amount), 0);
@@ -39,6 +42,20 @@ export default async function Home({ searchParams }) {
 
   const recentIncome = recentIncomeRes.data ?? [];
   const recentExpense = recentExpenseRes.data ?? [];
+
+  // カテゴリ別集計
+  const aggregateByCategory = (rows) => {
+    const map = {};
+    for (const r of rows ?? []) {
+      const cat = r.category || 'その他';
+      map[cat] = (map[cat] ?? 0) + Number(r.amount);
+    }
+    return Object.entries(map)
+      .map(([category, amount]) => ({ category, amount }))
+      .sort((a, b) => b.amount - a.amount);
+  };
+  const incomeByCategory = aggregateByCategory(incomeCatRes.data);
+  const expenseByCategory = aggregateByCategory(expenseCatRes.data);
 
   return (
     <div className="min-h-screen bg-gray-900 text-white p-6 max-w-2xl mx-auto">
@@ -149,6 +166,12 @@ export default async function Home({ searchParams }) {
             </div>
           )}
         </div>
+      </div>
+
+      {/* カテゴリ別円グラフ */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+        <CategoryPieChart data={expenseByCategory} title="支出カテゴリ別" />
+        <CategoryPieChart data={incomeByCategory} title="収入カテゴリ別" />
       </div>
     </div>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "next": "^15.0.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "recharts": "^3.8.1",
         "zod": "^4.1.0"
       },
       "devDependencies": {
@@ -1784,6 +1785,42 @@
         "@prisma/debug": "5.22.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -2155,6 +2192,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.104.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.104.0.tgz",
@@ -2318,6 +2367,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2352,11 +2464,17 @@
       "version": "19.1.11",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.11.tgz",
       "integrity": "sha512-lr3jdBw/BGj49Eps7EvqlUaoeA0xpj3pc0RoJkHpYaCHkVK7i28dKyImLQb3JVlqs3aYSXf7qYuWOW/fgZnTXQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -3410,6 +3528,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cmd-shim": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
@@ -3509,8 +3636,129 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3600,6 +3848,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3899,6 +4153,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.1.tgz",
+      "integrity": "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -4453,6 +4717,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -5013,6 +5283,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -5072,6 +5352,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6890,8 +7179,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -6936,6 +7247,51 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -6976,6 +7332,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -7860,6 +8222,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -8194,12 +8562,43 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "6.4.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "next": "^15.0.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "recharts": "^3.8.1",
     "zod": "^4.1.0"
   },
   "devDependencies": {

--- a/src/components/CategoryPieChart.tsx
+++ b/src/components/CategoryPieChart.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+type CategoryData = { category: string; amount: number };
+
+type Props = {
+  data: CategoryData[];
+  title: string;
+};
+
+const COLORS = [
+  '#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6',
+  '#06b6d4', '#f97316', '#84cc16', '#ec4899', '#6b7280',
+];
+
+const formatAmount = (v: number) => `¥${v.toLocaleString('ja-JP')}`;
+
+export default function CategoryPieChart({ data, title }: Props) {
+  if (data.length === 0) {
+    return (
+      <div className="bg-gray-800 rounded-xl p-6">
+        <h2 className="text-sm font-semibold text-gray-400 mb-2">{title}</h2>
+        <p className="text-xs text-gray-500">データなし</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-gray-800 rounded-xl p-6">
+      <h2 className="text-sm font-semibold text-gray-400 mb-4">{title}</h2>
+      <ResponsiveContainer width="100%" height={260}>
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="amount"
+            nameKey="category"
+            cx="50%"
+            cy="50%"
+            outerRadius={90}
+            label={({ name, percent }) =>
+              (percent ?? 0) > 0.05 ? `${name} ${((percent ?? 0) * 100).toFixed(0)}%` : ''
+            }
+            labelLine={false}
+          >
+            {data.map((_, i) => (
+              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+            ))}
+          </Pie>
+          <Tooltip formatter={(value: number) => formatAmount(value)} />
+          <Legend
+            formatter={(value) => (
+              <span className="text-xs text-gray-300">{value}</span>
+            )}
+          />
+        </PieChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- ローカル開発用デモデータ
+-- デモユーザー: demo@example.com / パスワード: demo1234
+-- ============================================================
+
+-- デモユーザーを auth.users に挿入
+-- handle_new_user トリガーが profiles も自動作成する
+INSERT INTO auth.users (
+  id, email, encrypted_password, email_confirmed_at,
+  created_at, updated_at, aud, role,
+  raw_app_meta_data, raw_user_meta_data
+)
+VALUES (
+  'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'::uuid,
+  'demo@example.com',
+  crypt('demo1234', gen_salt('bf')),
+  now(), now(), now(),
+  'authenticated', 'authenticated',
+  '{"provider":"email","providers":["email"]}',
+  '{"display_name":"デモユーザー"}'
+) ON CONFLICT (id) DO NOTHING;
+
+-- ─── 収入データ（3ヶ月分） ────────────────────────────────────────────────────
+INSERT INTO public.income (source, amount, category, entry_date, user_id) VALUES
+  -- 2026年3月
+  ('月給（3月分）',    320000, '給与',   '2026-03-25', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('フリーランス案件', 85000,  '副業',   '2026-03-15', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('メルカリ売上',     12000,  'その他', '2026-03-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  -- 2026年4月
+  ('月給（4月分）',    320000, '給与',   '2026-04-25', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('フリーランス案件', 120000, '副業',   '2026-04-18', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('春季賞与',         180000, '賞与',   '2026-04-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('メルカリ売上',     8500,   'その他', '2026-04-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  -- 2026年5月
+  ('月給（5月分）',    320000, '給与',   '2026-05-25', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('フリーランス案件', 95000,  '副業',   '2026-05-12', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+
+-- ─── 支出データ（3ヶ月分） ────────────────────────────────────────────────────
+INSERT INTO public.expense (source, amount, category, entry_date, user_id) VALUES
+  -- 2026年3月
+  ('家賃',           95000, '住居費',  '2026-03-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週1）', 6800,  '食費',   '2026-03-03', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週2）', 7200,  '食費',   '2026-03-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週3）', 6500,  '食費',   '2026-03-17', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週4）', 7800,  '食費',   '2026-03-24', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('ランチ代',        4500,  '外食費', '2026-03-12', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('飲み会',          8000,  '外食費', '2026-03-20', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('電気代',          8200,  '光熱費', '2026-03-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('ガス代',          3800,  '光熱費', '2026-03-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('交通費（定期）',  12000, '交通費', '2026-03-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スマホ代',        5500,  '通信費', '2026-03-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('映画・配信',      3200,  '娯楽費', '2026-03-15', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('病院',            2800,  '医療費', '2026-03-22', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  -- 2026年4月
+  ('家賃',           95000, '住居費',  '2026-04-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週1）', 7100,  '食費',   '2026-04-07', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週2）', 6900,  '食費',   '2026-04-14', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週3）', 8200,  '食費',   '2026-04-21', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週4）', 6600,  '食費',   '2026-04-28', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('花見',           15000, '外食費',  '2026-04-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('ランチ代',        5200,  '外食費', '2026-04-18', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('電気代',          7500,  '光熱費', '2026-04-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('ガス代',          3200,  '光熱費', '2026-04-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('交通費（定期）',  12000, '交通費', '2026-04-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スマホ代',        5500,  '通信費', '2026-04-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('春服',           22000, '衣服費',  '2026-04-12', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('映画・配信',      3200,  '娯楽費', '2026-04-15', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('ジム入会',        8000,  '娯楽費', '2026-04-20', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  -- 2026年5月
+  ('家賃',           95000, '住居費',  '2026-05-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週1）', 6700,  '食費',   '2026-05-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週2）', 7300,  '食費',   '2026-05-12', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週3）', 6900,  '食費',   '2026-05-19', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スーパー（週4）', 7500,  '食費',   '2026-05-26', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('GW旅行',         45000, '娯楽費',  '2026-05-03', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('ランチ代',        4800,  '外食費', '2026-05-14', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('電気代',          6800,  '光熱費', '2026-05-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('ガス代',          2900,  '光熱費', '2026-05-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('交通費（定期）',  12000, '交通費', '2026-05-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('スマホ代',        5500,  '通信費', '2026-05-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('映画・配信',      3200,  '娯楽費', '2026-05-15', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');


### PR DESCRIPTION
## Summary

- Recharts を導入（円グラフ）
- 支出・収入それぞれのカテゴリ別円グラフをダッシュボード下部に表示
- 選択中の月に連動して集計結果が変わる
- 5%未満のスライスはラベル非表示

## Test plan

- [ ] ダッシュボードで円グラフが表示されることを確認
- [ ] 月を切り替えるとグラフが更新されることを確認
- [ ] データなし月は「データなし」と表示されることを確認

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)