### PR TITLE
カテゴリマスタの追加とサブカテゴリ対応 (issue #25)

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,1 @@
+rm -rf .next

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm test

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm test
+npm run lint && npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm run build

--- a/__tests__/api/expense.test.ts
+++ b/__tests__/api/expense.test.ts
@@ -14,6 +14,10 @@ vi.mock('@/lib/supabaseServerClient', () => ({
   ),
 }));
 
+vi.mock('@/lib/supabaseAdmin', () => ({
+  supabaseAdmin: { from: vi.fn(), auth: { admin: { getUserById: vi.fn() } } },
+}));
+
 vi.mock('next/headers', () => ({
   cookies: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), delete: vi.fn() })),
 }));

--- a/__tests__/api/expense.test.ts
+++ b/__tests__/api/expense.test.ts
@@ -99,8 +99,10 @@ describe('POST /api/expense', () => {
     mockGetUser.mockResolvedValue({ data: { user: TEST_USER } });
   });
 
+  const SUBCATEGORY_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
   it('世帯未所属の場合 household_id: null で支出を作成できる', async () => {
-    const newRow = { id: 1, source: '食費', amount: 5000, category: '食費', entry_date: '2026-04-01', user_id: TEST_USER.id, household_id: null };
+    const newRow = { id: 1, source: '食費', amount: 5000, subcategory_id: SUBCATEGORY_ID, entry_date: '2026-04-01', user_id: TEST_USER.id, household_id: null };
     const membershipQ = makeQueryMock({ data: null, error: null });
     const insertQ = makeQueryMock({ data: [newRow], error: null });
     mockFrom
@@ -109,7 +111,7 @@ describe('POST /api/expense', () => {
 
     const req = new Request('http://localhost/api/expense', {
       method: 'POST',
-      body: JSON.stringify({ source: '食費', amount: 5000, category: '食費', entry_date: '2026-04-01' }),
+      body: JSON.stringify({ source: '食費', amount: 5000, subcategory_id: SUBCATEGORY_ID, entry_date: '2026-04-01' }),
     });
     const res = await POST(req);
     expect(res.status).toBe(200);
@@ -121,7 +123,7 @@ describe('POST /api/expense', () => {
 
   it('世帯所属中は household_id が自動付与される', async () => {
     const HOUSEHOLD_ID = 'hh-uuid-456';
-    const newRow = { id: 1, source: '食費', amount: 5000, category: '食費', entry_date: '2026-04-01', user_id: TEST_USER.id, household_id: HOUSEHOLD_ID };
+    const newRow = { id: 1, source: '食費', amount: 5000, subcategory_id: SUBCATEGORY_ID, entry_date: '2026-04-01', user_id: TEST_USER.id, household_id: HOUSEHOLD_ID };
     const membershipQ = makeQueryMock({ data: { household_id: HOUSEHOLD_ID }, error: null });
     const insertQ = makeQueryMock({ data: [newRow], error: null });
     mockFrom
@@ -130,7 +132,7 @@ describe('POST /api/expense', () => {
 
     const req = new Request('http://localhost/api/expense', {
       method: 'POST',
-      body: JSON.stringify({ source: '食費', amount: 5000, category: '食費', entry_date: '2026-04-01' }),
+      body: JSON.stringify({ source: '食費', amount: 5000, subcategory_id: SUBCATEGORY_ID, entry_date: '2026-04-01' }),
     });
     const res = await POST(req);
     expect(res.status).toBe(200);

--- a/__tests__/api/income.test.ts
+++ b/__tests__/api/income.test.ts
@@ -14,6 +14,10 @@ vi.mock('@/lib/supabaseServerClient', () => ({
   ),
 }));
 
+vi.mock('@/lib/supabaseAdmin', () => ({
+  supabaseAdmin: { from: vi.fn(), auth: { admin: { getUserById: vi.fn() } } },
+}));
+
 vi.mock('next/headers', () => ({
   cookies: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), delete: vi.fn() })),
 }));

--- a/__tests__/api/income.test.ts
+++ b/__tests__/api/income.test.ts
@@ -99,8 +99,10 @@ describe('POST /api/income', () => {
     mockGetUser.mockResolvedValue({ data: { user: TEST_USER } });
   });
 
+  const SUBCATEGORY_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+
   it('世帯未所属の場合 household_id: null で収入を作成できる', async () => {
-    const newRow = { id: 1, source: '給与', amount: 300000, category: '給与', entry_date: '2026-04-01', user_id: TEST_USER.id, household_id: null };
+    const newRow = { id: 1, source: '給与', amount: 300000, subcategory_id: SUBCATEGORY_ID, entry_date: '2026-04-01', user_id: TEST_USER.id, household_id: null };
     const membershipQ = makeQueryMock({ data: null, error: null });
     const insertQ = makeQueryMock({ data: [newRow], error: null });
     mockFrom
@@ -109,7 +111,7 @@ describe('POST /api/income', () => {
 
     const req = new Request('http://localhost/api/income', {
       method: 'POST',
-      body: JSON.stringify({ source: '給与', amount: 300000, category: '給与', entry_date: '2026-04-01' }),
+      body: JSON.stringify({ source: '給与', amount: 300000, subcategory_id: SUBCATEGORY_ID, entry_date: '2026-04-01' }),
     });
     const res = await POST(req);
     expect(res.status).toBe(200);
@@ -121,7 +123,7 @@ describe('POST /api/income', () => {
 
   it('世帯所属中は household_id が自動付与される', async () => {
     const HOUSEHOLD_ID = 'hh-uuid-123';
-    const newRow = { id: 1, source: '給与', amount: 300000, category: '給与', entry_date: '2026-04-01', user_id: TEST_USER.id, household_id: HOUSEHOLD_ID };
+    const newRow = { id: 1, source: '給与', amount: 300000, subcategory_id: SUBCATEGORY_ID, entry_date: '2026-04-01', user_id: TEST_USER.id, household_id: HOUSEHOLD_ID };
     const membershipQ = makeQueryMock({ data: { household_id: HOUSEHOLD_ID }, error: null });
     const insertQ = makeQueryMock({ data: [newRow], error: null });
     mockFrom
@@ -130,7 +132,7 @@ describe('POST /api/income', () => {
 
     const req = new Request('http://localhost/api/income', {
       method: 'POST',
-      body: JSON.stringify({ source: '給与', amount: 300000, category: '給与', entry_date: '2026-04-01' }),
+      body: JSON.stringify({ source: '給与', amount: 300000, subcategory_id: SUBCATEGORY_ID, entry_date: '2026-04-01' }),
     });
     const res = await POST(req);
     expect(res.status).toBe(200);

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { requireAuth } from '@/lib/apiHelpers';
+import { CategoryCreateSchema, zodErrorToMessages } from '@/lib/validation';
+
+// GET ?type=income|expense: カテゴリ一覧（マスタ + ユーザー独自）をサブカテゴリ付きで返す
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { supabase, user } = auth;
+
+  const type = req.nextUrl.searchParams.get('type');
+  if (type !== 'income' && type !== 'expense') {
+    return NextResponse.json({ error: 'type は income または expense を指定してください' }, { status: 400 });
+  }
+
+  try {
+    const { data: categories, error } = await supabase
+      .from('categories')
+      .select('id, name, type, user_id, sort_order, subcategories(id, name, user_id, sort_order)')
+      .eq('type', type)
+      .order('sort_order', { ascending: true });
+
+    if (error) throw error;
+
+    // マスタ → ユーザー独自の順で並べる
+    const sorted = (categories ?? []).sort((a, b) => {
+      if (a.user_id === null && b.user_id !== null) return -1;
+      if (a.user_id !== null && b.user_id === null) return 1;
+      return a.sort_order - b.sort_order;
+    });
+
+    // 各カテゴリのサブカテゴリも並び替え
+    const result = sorted.map(cat => ({
+      ...cat,
+      subcategories: [...((cat.subcategories as { id: string; name: string; user_id: string | null; sort_order: number }[]) ?? [])].sort((a, b) => {
+        if (a.user_id === null && b.user_id !== null) return -1;
+        if (a.user_id !== null && b.user_id === null) return 1;
+        return a.sort_order - b.sort_order;
+      }),
+    }));
+
+    return NextResponse.json({ categories: result }, { status: 200 });
+  } catch (e) {
+    console.error('GET categories error:', e);
+    return NextResponse.json({ error: 'カテゴリの取得に失敗しました' }, { status: 500 });
+  }
+}
+
+// POST: ユーザー独自カテゴリを作成
+export async function POST(request: Request) {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { supabase, user } = auth;
+
+  try {
+    const json = await request.json();
+    const parsed = CategoryCreateSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'validation_error', issues: zodErrorToMessages(parsed.error) },
+        { status: 400 }
+      );
+    }
+
+    const { data, error } = await supabase
+      .from('categories')
+      .insert({ name: parsed.data.name, type: parsed.data.type, user_id: user.id })
+      .select()
+      .single();
+
+    if (error) throw error;
+    return NextResponse.json({ category: data }, { status: 201 });
+  } catch (e) {
+    console.error('POST categories error:', e);
+    return NextResponse.json({ error: 'カテゴリの作成に失敗しました' }, { status: 500 });
+  }
+}

--- a/app/api/expense/route.ts
+++ b/app/api/expense/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
         { status: 400 }
       );
     }
-    const { source, amount, category, entry_date } = parsed.data as { source: string; amount: number; category: string; entry_date: string };
+    const { source, amount, subcategory_id, entry_date } = parsed.data as { source: string; amount: number; subcategory_id: string; entry_date: string };
 
     const { data: membership } = await supabase
       .from('household_members')
@@ -54,7 +54,7 @@ export async function POST(request: Request) {
 
     const { data, error } = await supabase
       .from('expense')
-      .insert([{ source, amount, category, entry_date, user_id: user.id, household_id: membership?.household_id ?? null }])
+      .insert([{ source, amount, subcategory_id, entry_date, user_id: user.id, household_id: membership?.household_id ?? null }])
       .select();
 
     if (error) throw error;

--- a/app/api/expense/route.ts
+++ b/app/api/expense/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { requireAuth, parseListParams } from '@/lib/apiHelpers';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { ExpenseCreateSchema, ExpenseUpdateSchema } from '@/lib/validation/expense';
 import { zodErrorToMessages } from '@/lib/validation/common';
 
@@ -47,7 +48,25 @@ export async function POST(request: Request) {
         { status: 400 }
       );
     }
-    const { source, amount, subcategory_id, entry_date } = parsed.data;
+    const { source, amount, entry_date } = parsed.data;
+    let { subcategory_id } = parsed.data;
+
+    // 未選択の場合はマスタの「未分類」（expense型）を自動セット
+    if (!subcategory_id) {
+      const { data: miscCat } = await supabaseAdmin
+        .from('categories')
+        .select('id')
+        .eq('name', '未分類').eq('type', 'expense').is('user_id', null)
+        .maybeSingle();
+      if (miscCat) {
+        const { data: miscSub } = await supabaseAdmin
+          .from('subcategories')
+          .select('id')
+          .eq('category_id', miscCat.id).eq('name', '未分類').is('user_id', null)
+          .maybeSingle();
+        subcategory_id = miscSub?.id ?? undefined;
+      }
+    }
 
     const { data: membership } = await supabase
       .from('household_members')

--- a/app/api/expense/route.ts
+++ b/app/api/expense/route.ts
@@ -11,7 +11,10 @@ export async function GET(req: NextRequest) {
 
   try {
     const params = parseListParams(new URL(req.url).searchParams);
-    let query = supabase.from('expense').select('*', { count: 'exact' });
+    let query = supabase.from('expense').select(
+      '*, subcategory:subcategory_id(name, category:category_id(name))',
+      { count: 'exact' }
+    );
 
     if (params.q)    query = query.ilike('source', `%${params.q}%`);
     if (params.from) query = query.gte('entry_date', params.from);
@@ -44,7 +47,7 @@ export async function POST(request: Request) {
         { status: 400 }
       );
     }
-    const { source, amount, subcategory_id, entry_date } = parsed.data as { source: string; amount: number; subcategory_id: string; entry_date: string };
+    const { source, amount, subcategory_id, entry_date } = parsed.data;
 
     const { data: membership } = await supabase
       .from('household_members')
@@ -54,7 +57,7 @@ export async function POST(request: Request) {
 
     const { data, error } = await supabase
       .from('expense')
-      .insert([{ source, amount, subcategory_id, entry_date, user_id: user.id, household_id: membership?.household_id ?? null }])
+      .insert([{ source, amount, subcategory_id: subcategory_id ?? null, entry_date, user_id: user.id, household_id: membership?.household_id ?? null }])
       .select();
 
     if (error) throw error;
@@ -79,7 +82,7 @@ export async function PATCH(request: Request) {
         { status: 400 }
       );
     }
-    const { id, ...patch } = parsed.data as { id: number; source?: string; amount?: number; category?: string; entry_date?: string };
+    const { id, ...patch } = parsed.data;
 
     const { data, error } = await supabase.from('expense').update(patch).eq('id', id).select();
     if (error) throw error;

--- a/app/api/income/route.ts
+++ b/app/api/income/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { requireAuth, parseListParams } from '@/lib/apiHelpers';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { IncomeCreateSchema, IncomeUpdateSchema, zodErrorToMessages } from '@/lib/validation';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
@@ -43,7 +44,25 @@ export async function POST(request: Request) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'validation_error', issues: zodErrorToMessages(parsed.error) }, { status: 400 });
     }
-    const { source, amount, subcategory_id, entry_date } = parsed.data;
+    const { source, amount, entry_date } = parsed.data;
+    let { subcategory_id } = parsed.data;
+
+    // 未選択の場合はマスタの「未分類」（income型）を自動セット
+    if (!subcategory_id) {
+      const { data: miscCat } = await supabaseAdmin
+        .from('categories')
+        .select('id')
+        .eq('name', '未分類').eq('type', 'income').is('user_id', null)
+        .maybeSingle();
+      if (miscCat) {
+        const { data: miscSub } = await supabaseAdmin
+          .from('subcategories')
+          .select('id')
+          .eq('category_id', miscCat.id).eq('name', '未分類').is('user_id', null)
+          .maybeSingle();
+        subcategory_id = miscSub?.id ?? undefined;
+      }
+    }
 
     const { data: membership } = await supabase
       .from('household_members')

--- a/app/api/income/route.ts
+++ b/app/api/income/route.ts
@@ -10,7 +10,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   try {
     const params = parseListParams(new URL(req.url).searchParams);
-    let query = supabase.from('income').select('*', { count: 'exact' });
+    let query = supabase.from('income').select(
+      '*, subcategory:subcategory_id(name, category:category_id(name))',
+      { count: 'exact' }
+    );
 
     if (params.q)    query = query.ilike('source', `%${params.q}%`);
     if (params.from) query = query.gte('entry_date', params.from);
@@ -40,7 +43,7 @@ export async function POST(request: Request) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'validation_error', issues: zodErrorToMessages(parsed.error) }, { status: 400 });
     }
-    const { source, amount, subcategory_id, entry_date } = parsed.data as { source: string; amount: number; subcategory_id: string; entry_date: string };
+    const { source, amount, subcategory_id, entry_date } = parsed.data;
 
     const { data: membership } = await supabase
       .from('household_members')
@@ -50,7 +53,7 @@ export async function POST(request: Request) {
 
     const { data, error } = await supabase
       .from('income')
-      .insert([{ source, amount, subcategory_id, entry_date, user_id: user.id, household_id: membership?.household_id ?? null }])
+      .insert([{ source, amount, subcategory_id: subcategory_id ?? null, entry_date, user_id: user.id, household_id: membership?.household_id ?? null }])
       .select();
 
     if (error) throw error;
@@ -72,7 +75,7 @@ export async function PATCH(request: Request) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'validation_error', issues: zodErrorToMessages(parsed.error) }, { status: 400 });
     }
-    const { id, ...rest } = parsed.data as { id: number; source?: string; amount?: number; category?: string; entry_date?: string };
+    const { id, ...rest } = parsed.data;
 
     const { data, error } = await supabase.from('income').update(rest).eq('id', id).select();
     if (error) throw error;
@@ -101,4 +104,3 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: '削除に失敗しました' }, { status: 500 });
   }
 }
-

--- a/app/api/income/route.ts
+++ b/app/api/income/route.ts
@@ -40,7 +40,7 @@ export async function POST(request: Request) {
     if (!parsed.success) {
       return NextResponse.json({ error: 'validation_error', issues: zodErrorToMessages(parsed.error) }, { status: 400 });
     }
-    const { source, amount, category, entry_date } = parsed.data as { source: string; amount: number; category: string; entry_date: string };
+    const { source, amount, subcategory_id, entry_date } = parsed.data as { source: string; amount: number; subcategory_id: string; entry_date: string };
 
     const { data: membership } = await supabase
       .from('household_members')
@@ -50,7 +50,7 @@ export async function POST(request: Request) {
 
     const { data, error } = await supabase
       .from('income')
-      .insert([{ source, amount, category, entry_date, user_id: user.id, household_id: membership?.household_id ?? null }])
+      .insert([{ source, amount, subcategory_id, entry_date, user_id: user.id, household_id: membership?.household_id ?? null }])
       .select();
 
     if (error) throw error;

--- a/app/api/subcategories/route.ts
+++ b/app/api/subcategories/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/apiHelpers';
+import { SubcategoryCreateSchema, zodErrorToMessages } from '@/lib/validation';
+
+// POST: ユーザー独自サブカテゴリを作成
+export async function POST(request: Request) {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { supabase, user } = auth;
+
+  try {
+    const json = await request.json();
+    const parsed = SubcategoryCreateSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'validation_error', issues: zodErrorToMessages(parsed.error) },
+        { status: 400 }
+      );
+    }
+
+    // 指定カテゴリが参照可能か確認
+    const { data: cat } = await supabase
+      .from('categories')
+      .select('id')
+      .eq('id', parsed.data.category_id)
+      .maybeSingle();
+
+    if (!cat) return NextResponse.json({ error: 'カテゴリが見つかりません' }, { status: 404 });
+
+    const { data, error } = await supabase
+      .from('subcategories')
+      .insert({ category_id: parsed.data.category_id, name: parsed.data.name, user_id: user.id })
+      .select()
+      .single();
+
+    if (error) throw error;
+    return NextResponse.json({ subcategory: data }, { status: 201 });
+  } catch (e) {
+    console.error('POST subcategories error:', e);
+    return NextResponse.json({ error: 'サブカテゴリの作成に失敗しました' }, { status: 500 });
+  }
+}

--- a/app/expense/page.tsx
+++ b/app/expense/page.tsx
@@ -65,13 +65,13 @@ export default function ExpensePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [q, month, offset]);
 
-  const handleSave = async (payload: { id?: number; source: string; amount: number; category: string; entry_date: string }) => {
+  const handleSave = async (payload: { id?: number; source: string; amount: number; subcategory_id: string; entry_date: string }) => {
     try {
       const method = payload.id ? 'PATCH' : 'POST';
       const body = JSON.stringify(
         payload.id
           ? payload
-          : { source: payload.source, amount: payload.amount, category: payload.category, entry_date: payload.entry_date }
+          : { source: payload.source, amount: payload.amount, subcategory_id: payload.subcategory_id, entry_date: payload.entry_date }
       );
       const res = await fetch('/api/expense', {
         method,
@@ -175,7 +175,7 @@ export default function ExpensePage() {
                 <div className="flex justify-between items-center">
                   <div>
                     <h3 className="font-bold text-lg text-white">{row?.source ?? '(無題)'}</h3>
-                    <p className="text-sm text-gray-400">カテゴリ: {row.category ?? '—'}</p>
+                    <p className="text-sm text-gray-400">カテゴリ: {(row as { subcategory_name?: string }).subcategory_name ?? '—'}</p>
                     <p className="text-sm text-gray-400">日付: {entryDate}</p>
                   </div>
                   <div className="flex items-center gap-3">
@@ -217,7 +217,8 @@ export default function ExpensePage() {
       <EditEntryModal
         open={modalOpen}
         title={editItem ? '支出を編集' : '支出を追加'}
-        initial={editItem ? { id: editItem.id, source: editItem.source, amount: editItem.amount, category: editItem.category ?? '', entry_date: editItem.entry_date ?? '' } : null}
+        type="expense"
+        initial={editItem ? { id: editItem.id, source: editItem.source, amount: editItem.amount, subcategory_id: (editItem as { subcategory_id?: string }).subcategory_id ?? '', entry_date: editItem.entry_date ?? '' } : null}
         onClose={() => {
           setModalOpen(false);
           setEditItem(null);

--- a/app/expense/page.tsx
+++ b/app/expense/page.tsx
@@ -175,7 +175,11 @@ export default function ExpensePage() {
                 <div className="flex justify-between items-center">
                   <div>
                     <h3 className="font-bold text-lg text-white">{row?.source ?? '(無題)'}</h3>
-                    <p className="text-sm text-gray-400">カテゴリ: {(row as { subcategory_name?: string }).subcategory_name ?? '—'}</p>
+                    <p className="text-sm text-gray-400">カテゴリ: {(() => {
+                        type Sub = { name: string; category?: { name: string } | null } | null;
+                        const sub = (row as { subcategory?: Sub }).subcategory;
+                        return sub ? (sub.category ? `${sub.category.name} › ${sub.name}` : sub.name) : '未分類';
+                      })()}</p>
                     <p className="text-sm text-gray-400">日付: {entryDate}</p>
                   </div>
                   <div className="flex items-center gap-3">

--- a/app/income/page.tsx
+++ b/app/income/page.tsx
@@ -207,7 +207,11 @@ export default function IncomePage() {
                 <div className="flex justify-between items-center">
                   <div>
                     <h3 className="font-bold text-lg text-white">{income?.source ?? '(無題)'}</h3>
-                    <p className="text-sm text-gray-400">カテゴリ: {(income as { subcategory_name?: string }).subcategory_name ?? '—'}</p>
+                    <p className="text-sm text-gray-400">カテゴリ: {(() => {
+                        type Sub = { name: string; category?: { name: string } | null } | null;
+                        const sub = (income as { subcategory?: Sub }).subcategory;
+                        return sub ? (sub.category ? `${sub.category.name} › ${sub.name}` : sub.name) : '未分類';
+                      })()}</p>
                     <p className="text-sm text-gray-400">日付: {entryDate}</p>
                   </div>
                   <div className="flex items-center gap-3">

--- a/app/income/page.tsx
+++ b/app/income/page.tsx
@@ -107,10 +107,10 @@ export default function IncomePage() {
     setModalOpen(true);
   };
 
-  const handleSave = async (payload: { id?: number; source: string; amount: number; category: string; entry_date: string }) => {
+  const handleSave = async (payload: { id?: number; source: string; amount: number; subcategory_id: string; entry_date: string }) => {
     try {
       const method = payload.id ? 'PATCH' : 'POST';
-      const body = JSON.stringify(payload.id ? payload : { source: payload.source, amount: payload.amount, category: payload.category, entry_date: payload.entry_date });
+      const body = JSON.stringify(payload.id ? payload : { source: payload.source, amount: payload.amount, subcategory_id: payload.subcategory_id, entry_date: payload.entry_date });
       const res = await fetch('/api/income', {
         method,
         headers: { 'Content-Type': 'application/json' },
@@ -207,7 +207,7 @@ export default function IncomePage() {
                 <div className="flex justify-between items-center">
                   <div>
                     <h3 className="font-bold text-lg text-white">{income?.source ?? '(無題)'}</h3>
-                    <p className="text-sm text-gray-400">カテゴリ: {income.category ?? '—'}</p>
+                    <p className="text-sm text-gray-400">カテゴリ: {(income as { subcategory_name?: string }).subcategory_name ?? '—'}</p>
                     <p className="text-sm text-gray-400">日付: {entryDate}</p>
                   </div>
                   <div className="flex items-center gap-3">
@@ -254,7 +254,8 @@ export default function IncomePage() {
       <EditEntryModal
         open={modalOpen}
         title={editItem ? '収入を編集' : '収入を追加'}
-        initial={editItem ? { id: editItem.id, source: editItem.source, amount: editItem.amount, category: editItem.category ?? '', entry_date: editItem.entry_date ?? '' } : null}
+        type="income"
+        initial={editItem ? { id: editItem.id, source: editItem.source, amount: editItem.amount, subcategory_id: (editItem as { subcategory_id?: string }).subcategory_id ?? '', entry_date: editItem.entry_date ?? '' } : null}
         onClose={() => {
           setModalOpen(false);
           setEditItem(null);

--- a/app/page.js
+++ b/app/page.js
@@ -32,8 +32,8 @@ export default async function Home({ searchParams }) {
     supabase.from('expense').select('amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
     supabase.from('income').select('id, source, amount, entry_date').order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(5),
     supabase.from('expense').select('id, source, amount, entry_date').order('entry_date', { ascending: false }).order('created_at', { ascending: false }).limit(5),
-    supabase.from('income').select('category, amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
-    supabase.from('expense').select('category, amount').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
+    supabase.from('income').select('amount, subcategory:subcategory_id(name, category:category_id(name))').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
+    supabase.from('expense').select('amount, subcategory:subcategory_id(name, category:category_id(name))').gte('entry_date', fromDate).lt('entry_date', nextMonthStr),
   ]);
 
   const totalIncome = (incomeRes.data ?? []).reduce((sum, r) => sum + Number(r.amount), 0);
@@ -43,11 +43,11 @@ export default async function Home({ searchParams }) {
   const recentIncome = recentIncomeRes.data ?? [];
   const recentExpense = recentExpenseRes.data ?? [];
 
-  // カテゴリ別集計
+  // カテゴリ別集計（メインカテゴリ単位で集計）
   const aggregateByCategory = (rows) => {
     const map = {};
     for (const r of rows ?? []) {
-      const cat = r.category || 'その他';
+      const cat = r.subcategory?.category?.name ?? '未分類';
       map[cat] = (map[cat] ?? 0) + Number(r.amount);
     }
     return Object.entries(map)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "autoprefixer": "^10.4.20",
         "eslint": "^8",
         "eslint-config-next": "15.0.3",
+        "husky": "^9.1.7",
         "postcss": "^8.4.49",
         "prisma": "^5.22.0",
         "supabase": "^2.34.3",
@@ -5262,6 +5263,22 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iceberg-js": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "debug": "NODE_OPTIONS='--inspect' next dev",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:rls": "bash supabase/tests/rls_check.sh"
+    "test:rls": "bash supabase/tests/rls_check.sh",
+    "prepare": "husky"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
@@ -31,6 +32,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^8",
     "eslint-config-next": "15.0.3",
+    "husky": "^9.1.7",
     "postcss": "^8.4.49",
     "prisma": "^5.22.0",
     "supabase": "^2.34.3",

--- a/src/components/CategorySelect.tsx
+++ b/src/components/CategorySelect.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type Subcategory = { id: string; name: string; user_id: string | null };
+type Category = { id: string; name: string; user_id: string | null; subcategories: Subcategory[] };
+
+type Props = {
+  type: 'income' | 'expense';
+  value: string;           // subcategory_id
+  onChange: (subcategoryId: string) => void;
+};
+
+const INPUT_CLS = 'rounded border border-gray-600 bg-gray-700 p-2 text-white placeholder-gray-400 text-sm focus:outline-none focus:border-blue-500';
+const BTN_CLS   = 'text-xs text-blue-400 hover:text-blue-300 mt-1';
+
+export default function CategorySelect({ type, value, onChange }: Props) {
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [selectedCatId, setSelectedCatId] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  // 新規カテゴリ入力
+  const [newCatName, setNewCatName] = useState('');
+  const [addingCat, setAddingCat] = useState(false);
+  const [savingCat, setSavingCat] = useState(false);
+
+  // 新規サブカテゴリ入力
+  const [newSubName, setNewSubName] = useState('');
+  const [addingSub, setAddingSub] = useState(false);
+  const [savingSub, setSavingSub] = useState(false);
+
+  useEffect(() => {
+    fetch(`/api/categories?type=${type}`)
+      .then(r => r.json())
+      .then(({ categories: cats }) => {
+        setCategories(cats ?? []);
+        // value から初期の selectedCatId を逆引き
+        if (value) {
+          const cat = (cats ?? []).find((c: Category) =>
+            c.subcategories.some((s: Subcategory) => s.id === value)
+          );
+          if (cat) setSelectedCatId(cat.id);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [type]);
+
+  // value が外から変わった時の同期
+  useEffect(() => {
+    if (!value) { setSelectedCatId(''); return; }
+    const cat = categories.find(c => c.subcategories.some(s => s.id === value));
+    if (cat) setSelectedCatId(cat.id);
+  }, [value, categories]);
+
+  const selectedCat = categories.find(c => c.id === selectedCatId);
+  const subcategories = selectedCat?.subcategories ?? [];
+
+  const handleCatChange = (catId: string) => {
+    setSelectedCatId(catId);
+    onChange(''); // サブを未選択に
+    setAddingCat(false);
+    setAddingSub(false);
+  };
+
+  const handleSubChange = (subId: string) => {
+    onChange(subId);
+    setAddingSub(false);
+  };
+
+  const handleAddCategory = async () => {
+    if (!newCatName.trim()) return;
+    setSavingCat(true);
+    try {
+      const res = await fetch('/api/categories', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: newCatName.trim(), type }),
+      });
+      const { category } = await res.json();
+      setCategories(prev => [...prev, { ...category, subcategories: [] }]);
+      setSelectedCatId(category.id);
+      setNewCatName('');
+      setAddingCat(false);
+      onChange('');
+    } finally {
+      setSavingCat(false);
+    }
+  };
+
+  const handleAddSubcategory = async () => {
+    if (!newSubName.trim() || !selectedCatId) return;
+    setSavingSub(true);
+    try {
+      const res = await fetch('/api/subcategories', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ category_id: selectedCatId, name: newSubName.trim() }),
+      });
+      const { subcategory } = await res.json();
+      setCategories(prev => prev.map(c =>
+        c.id === selectedCatId
+          ? { ...c, subcategories: [...c.subcategories, subcategory] }
+          : c
+      ));
+      onChange(subcategory.id);
+      setNewSubName('');
+      setAddingSub(false);
+    } finally {
+      setSavingSub(false);
+    }
+  };
+
+  if (loading) return <p className="text-xs text-gray-400">読み込み中...</p>;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* メインカテゴリ */}
+      <div className="flex flex-col gap-1">
+        <label className="text-xs text-gray-400">カテゴリ</label>
+        {addingCat ? (
+          <div className="flex gap-2">
+            <input
+              autoFocus
+              type="text"
+              placeholder="新しいカテゴリ名"
+              value={newCatName}
+              onChange={e => setNewCatName(e.target.value)}
+              onKeyDown={e => e.key === 'Enter' && handleAddCategory()}
+              className={`${INPUT_CLS} flex-1`}
+            />
+            <button type="button" onClick={handleAddCategory} disabled={savingCat}
+              className="rounded bg-blue-700 px-3 py-1 text-xs text-white hover:bg-blue-600 disabled:opacity-50">
+              {savingCat ? '...' : '追加'}
+            </button>
+            <button type="button" onClick={() => setAddingCat(false)}
+              className="text-xs text-gray-400 hover:text-white">✕</button>
+          </div>
+        ) : (
+          <>
+            <select value={selectedCatId} onChange={e => handleCatChange(e.target.value)}
+              className={INPUT_CLS}>
+              <option value="">選択してください</option>
+              {categories.map(c => (
+                <option key={c.id} value={c.id}>{c.name}{c.user_id ? ' ★' : ''}</option>
+              ))}
+            </select>
+            <button type="button" onClick={() => setAddingCat(true)} className={BTN_CLS}>
+              ＋ カテゴリを新規作成
+            </button>
+          </>
+        )}
+      </div>
+
+      {/* サブカテゴリ（メインカテゴリ選択後に表示） */}
+      {selectedCatId && !addingCat && (
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-gray-400">サブカテゴリ</label>
+          {addingSub ? (
+            <div className="flex gap-2">
+              <input
+                autoFocus
+                type="text"
+                placeholder="新しいサブカテゴリ名"
+                value={newSubName}
+                onChange={e => setNewSubName(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleAddSubcategory()}
+                className={`${INPUT_CLS} flex-1`}
+              />
+              <button type="button" onClick={handleAddSubcategory} disabled={savingSub}
+                className="rounded bg-blue-700 px-3 py-1 text-xs text-white hover:bg-blue-600 disabled:opacity-50">
+                {savingSub ? '...' : '追加'}
+              </button>
+              <button type="button" onClick={() => setAddingSub(false)}
+                className="text-xs text-gray-400 hover:text-white">✕</button>
+            </div>
+          ) : (
+            <>
+              <select value={value} onChange={e => handleSubChange(e.target.value)}
+                className={INPUT_CLS}>
+                <option value="">選択してください</option>
+                {subcategories.map(s => (
+                  <option key={s.id} value={s.id}>{s.name}{s.user_id ? ' ★' : ''}</option>
+                ))}
+              </select>
+              <button type="button" onClick={() => setAddingSub(true)} className={BTN_CLS}>
+                ＋ サブカテゴリを新規作成
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/CategorySelect.tsx
+++ b/src/components/CategorySelect.tsx
@@ -1,182 +1,188 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 type Subcategory = { id: string; name: string; user_id: string | null };
-type Category = { id: string; name: string; user_id: string | null; subcategories: Subcategory[] };
+type Category    = { id: string; name: string; user_id: string | null; subcategories: Subcategory[] };
 
 type Props = {
   type: 'income' | 'expense';
-  value: string;           // subcategory_id
+  value: string;                        // subcategory_id (空文字 = 未分類)
   onChange: (subcategoryId: string) => void;
 };
 
-const INPUT_CLS = 'rounded border border-gray-600 bg-gray-700 p-2 text-white placeholder-gray-400 text-sm focus:outline-none focus:border-blue-500';
-const BTN_CLS   = 'text-xs text-blue-400 hover:text-blue-300 mt-1';
-
 export default function CategorySelect({ type, value, onChange }: Props) {
   const [categories, setCategories] = useState<Category[]>([]);
-  const [selectedCatId, setSelectedCatId] = useState('');
-  const [loading, setLoading] = useState(true);
-
-  // 新規カテゴリ入力
-  const [newCatName, setNewCatName] = useState('');
-  const [addingCat, setAddingCat] = useState(false);
-  const [savingCat, setSavingCat] = useState(false);
-
-  // 新規サブカテゴリ入力
+  const [open, setOpen] = useState(false);
+  const [hoveredCatId, setHoveredCatId] = useState('');
   const [newSubName, setNewSubName] = useState('');
-  const [addingSub, setAddingSub] = useState(false);
-  const [savingSub, setSavingSub] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     fetch(`/api/categories?type=${type}`)
       .then(r => r.json())
-      .then(({ categories: cats }) => { setCategories(cats ?? []); })
+      .then(({ categories: cats }) => {
+        setCategories(cats ?? []);
+        if (cats?.length) setHoveredCatId(cats[0].id);
+      })
       .finally(() => setLoading(false));
   }, [type]);
 
-  // value が外から変わった時の同期
+  // value が変わったらホバーカテゴリを同期
   useEffect(() => {
-    if (!value) { setSelectedCatId(''); return; }
+    if (!value || !categories.length) return;
     const cat = categories.find(c => c.subcategories.some(s => s.id === value));
-    if (cat) setSelectedCatId(cat.id);
+    if (cat) setHoveredCatId(cat.id);
   }, [value, categories]);
 
-  const selectedCat = categories.find(c => c.id === selectedCatId);
-  const subcategories = selectedCat?.subcategories ?? [];
+  // パネル外クリックで閉じる
+  useEffect(() => {
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
 
-  const handleCatChange = (catId: string) => {
-    setSelectedCatId(catId);
-    onChange(''); // サブを未選択に
-    setAddingCat(false);
-    setAddingSub(false);
-  };
+  const allSubs = categories.flatMap(c => c.subcategories);
+  const selectedSub = allSubs.find(s => s.id === value);
+  const selectedCat = selectedSub
+    ? categories.find(c => c.subcategories.some(s => s.id === value))
+    : null;
 
-  const handleSubChange = (subId: string) => {
+  const displayText = selectedSub
+    ? `${selectedCat?.name} › ${selectedSub.name}`
+    : '未分類';
+
+  const hoveredCat = categories.find(c => c.id === hoveredCatId) ?? categories[0];
+
+  const handleSelect = (subId: string) => {
     onChange(subId);
-    setAddingSub(false);
+    setOpen(false);
+    setNewSubName('');
   };
 
-  const handleAddCategory = async () => {
-    if (!newCatName.trim()) return;
-    setSavingCat(true);
-    try {
-      const res = await fetch('/api/categories', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: newCatName.trim(), type }),
-      });
-      const { category } = await res.json();
-      setCategories(prev => [...prev, { ...category, subcategories: [] }]);
-      setSelectedCatId(category.id);
-      setNewCatName('');
-      setAddingCat(false);
-      onChange('');
-    } finally {
-      setSavingCat(false);
-    }
+  const handleClear = () => {
+    onChange('');
+    setOpen(false);
   };
 
-  const handleAddSubcategory = async () => {
-    if (!newSubName.trim() || !selectedCatId) return;
-    setSavingSub(true);
+  const handleAddSub = async () => {
+    if (!newSubName.trim() || !hoveredCat) return;
+    setSaving(true);
     try {
       const res = await fetch('/api/subcategories', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ category_id: selectedCatId, name: newSubName.trim() }),
+        body: JSON.stringify({ category_id: hoveredCat.id, name: newSubName.trim() }),
       });
+      if (!res.ok) return;
       const { subcategory } = await res.json();
       setCategories(prev => prev.map(c =>
-        c.id === selectedCatId
+        c.id === hoveredCat.id
           ? { ...c, subcategories: [...c.subcategories, subcategory] }
           : c
       ));
-      onChange(subcategory.id);
+      handleSelect(subcategory.id);
       setNewSubName('');
-      setAddingSub(false);
     } finally {
-      setSavingSub(false);
+      setSaving(false);
     }
   };
 
-  if (loading) return <p className="text-xs text-gray-400">読み込み中...</p>;
-
   return (
-    <div className="flex flex-col gap-2">
-      {/* メインカテゴリ */}
-      <div className="flex flex-col gap-1">
-        <label className="text-xs text-gray-400">カテゴリ</label>
-        {addingCat ? (
-          <div className="flex gap-2">
-            <input
-              autoFocus
-              type="text"
-              placeholder="新しいカテゴリ名"
-              value={newCatName}
-              onChange={e => setNewCatName(e.target.value)}
-              onKeyDown={e => e.key === 'Enter' && handleAddCategory()}
-              className={`${INPUT_CLS} flex-1`}
-            />
-            <button type="button" onClick={handleAddCategory} disabled={savingCat}
-              className="rounded bg-blue-700 px-3 py-1 text-xs text-white hover:bg-blue-600 disabled:opacity-50">
-              {savingCat ? '...' : '追加'}
-            </button>
-            <button type="button" onClick={() => setAddingCat(false)}
-              className="text-xs text-gray-400 hover:text-white">✕</button>
-          </div>
-        ) : (
-          <>
-            <select value={selectedCatId} onChange={e => handleCatChange(e.target.value)}
-              className={INPUT_CLS}>
-              <option value="">選択してください</option>
-              {categories.map(c => (
-                <option key={c.id} value={c.id}>{c.name}{c.user_id ? ' ★' : ''}</option>
-              ))}
-            </select>
-            <button type="button" onClick={() => setAddingCat(true)} className={BTN_CLS}>
-              ＋ カテゴリを新規作成
-            </button>
-          </>
-        )}
-      </div>
+    <div className="relative" ref={panelRef}>
+      {/* トリガーボタン */}
+      <button
+        type="button"
+        onClick={() => {
+          if (!hoveredCatId && categories.length) setHoveredCatId(categories[0].id);
+          setOpen(v => !v);
+        }}
+        className="w-full flex items-center justify-between rounded border border-gray-600 bg-gray-700 px-3 py-2 text-sm hover:bg-gray-600 transition-colors"
+      >
+        <span className={selectedSub ? 'text-white' : 'text-gray-400'}>
+          {loading ? '読み込み中...' : displayText}
+        </span>
+        <span className="text-gray-400 ml-2 text-xs">{open ? '▴' : '▾'}</span>
+      </button>
 
-      {/* サブカテゴリ（メインカテゴリ選択後に表示） */}
-      {selectedCatId && !addingCat && (
-        <div className="flex flex-col gap-1">
-          <label className="text-xs text-gray-400">サブカテゴリ</label>
-          {addingSub ? (
-            <div className="flex gap-2">
-              <input
-                autoFocus
-                type="text"
-                placeholder="新しいサブカテゴリ名"
-                value={newSubName}
-                onChange={e => setNewSubName(e.target.value)}
-                onKeyDown={e => e.key === 'Enter' && handleAddSubcategory()}
-                className={`${INPUT_CLS} flex-1`}
-              />
-              <button type="button" onClick={handleAddSubcategory} disabled={savingSub}
-                className="rounded bg-blue-700 px-3 py-1 text-xs text-white hover:bg-blue-600 disabled:opacity-50">
-                {savingSub ? '...' : '追加'}
-              </button>
-              <button type="button" onClick={() => setAddingSub(false)}
-                className="text-xs text-gray-400 hover:text-white">✕</button>
-            </div>
-          ) : (
-            <>
-              <select value={value} onChange={e => handleSubChange(e.target.value)}
-                className={INPUT_CLS}>
-                <option value="">選択してください</option>
-                {subcategories.map(s => (
-                  <option key={s.id} value={s.id}>{s.name}{s.user_id ? ' ★' : ''}</option>
+      {/* フライアウトパネル */}
+      {open && !loading && (
+        <div className="absolute z-50 top-full left-0 mt-1 flex rounded-lg border border-gray-600 bg-gray-800 shadow-2xl overflow-hidden">
+
+          {/* 左列: メインカテゴリ */}
+          <div className="w-44 overflow-y-auto max-h-72 border-r border-gray-700 py-1">
+            {/* 未分類クリア */}
+            <button
+              type="button"
+              onClick={handleClear}
+              className={`w-full text-left px-3 py-1.5 text-xs transition-colors ${
+                !value ? 'text-blue-400 bg-gray-700' : 'text-gray-400 hover:bg-gray-700 hover:text-white'
+              }`}
+            >
+              未分類（なし）
+            </button>
+            <div className="border-t border-gray-700 my-1" />
+            {categories.map(cat => (
+              <div
+                key={cat.id}
+                onMouseEnter={() => setHoveredCatId(cat.id)}
+                onClick={() => setHoveredCatId(cat.id)}
+                className={`flex items-center justify-between px-3 py-1.5 text-sm cursor-pointer transition-colors ${
+                  hoveredCatId === cat.id ? 'bg-gray-700' : 'hover:bg-gray-750'
+                } ${selectedCat?.id === cat.id ? 'text-blue-400' : 'text-white'}`}
+              >
+                <span>{cat.name}{cat.user_id ? ' ★' : ''}</span>
+                <span className="text-gray-500 text-xs">›</span>
+              </div>
+            ))}
+          </div>
+
+          {/* 右列: サブカテゴリ + インライン追加 */}
+          {hoveredCat && (
+            <div className="w-48 flex flex-col">
+              <div className="overflow-y-auto max-h-60 py-1 flex-1">
+                {hoveredCat.subcategories.map(sub => (
+                  <button
+                    key={sub.id}
+                    type="button"
+                    onClick={() => handleSelect(sub.id)}
+                    className={`w-full text-left px-3 py-1.5 text-sm transition-colors ${
+                      value === sub.id
+                        ? 'bg-blue-600 text-white font-medium'
+                        : 'text-white hover:bg-gray-700'
+                    }`}
+                  >
+                    {sub.name}{sub.user_id ? ' ★' : ''}
+                  </button>
                 ))}
-              </select>
-              <button type="button" onClick={() => setAddingSub(true)} className={BTN_CLS}>
-                ＋ サブカテゴリを新規作成
-              </button>
-            </>
+              </div>
+              {/* サブカテゴリのインライン新規追加 */}
+              <div className="border-t border-gray-700 px-2 py-2 flex gap-1 items-center">
+                <input
+                  type="text"
+                  placeholder="項目を追加"
+                  value={newSubName}
+                  onChange={e => setNewSubName(e.target.value)}
+                  onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), handleAddSub())}
+                  className="flex-1 text-xs bg-gray-700 border border-gray-600 rounded px-2 py-1 text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                />
+                <button
+                  type="button"
+                  onClick={handleAddSub}
+                  disabled={saving || !newSubName.trim()}
+                  title="追加して選択"
+                  className="text-gray-400 hover:text-white disabled:opacity-40 px-1 text-base leading-none"
+                >
+                  {saving ? '…' : '＋'}
+                </button>
+              </div>
+            </div>
           )}
         </div>
       )}

--- a/src/components/CategorySelect.tsx
+++ b/src/components/CategorySelect.tsx
@@ -32,16 +32,7 @@ export default function CategorySelect({ type, value, onChange }: Props) {
   useEffect(() => {
     fetch(`/api/categories?type=${type}`)
       .then(r => r.json())
-      .then(({ categories: cats }) => {
-        setCategories(cats ?? []);
-        // value から初期の selectedCatId を逆引き
-        if (value) {
-          const cat = (cats ?? []).find((c: Category) =>
-            c.subcategories.some((s: Subcategory) => s.id === value)
-          );
-          if (cat) setSelectedCatId(cat.id);
-        }
-      })
+      .then(({ categories: cats }) => { setCategories(cats ?? []); })
       .finally(() => setLoading(false));
   }, [type]);
 

--- a/src/components/EditEntryModal.tsx
+++ b/src/components/EditEntryModal.tsx
@@ -2,54 +2,49 @@
 
 import { useEffect, useState } from 'react';
 import Modal from './Modal';
+import CategorySelect from './CategorySelect';
 
 export type EditEntry = {
   id: number;
   source: string | null;
   amount: number | string;
-  category?: string | null;
-  entry_date?: string | null; // YYYY-MM-DD
+  subcategory_id?: string | null;
+  entry_date?: string | null;
 };
 
 type Props = {
   open: boolean;
   title?: string;
+  type: 'income' | 'expense';
   initial: EditEntry | null;
   onClose: () => void;
-  onSave: (payload: { id?: number; source: string; amount: number; category: string; entry_date: string }) => Promise<void>;
+  onSave: (payload: { id?: number; source: string; amount: number; subcategory_id: string; entry_date: string }) => Promise<void>;
   error?: string;
   setError?: (msg: string) => void;
 };
 
 export default function EditEntryModal({
-  open,
-  title,
-  initial,
-  onClose,
-  onSave,
-  error,
-  setError,
+  open, title, type, initial, onClose, onSave, error, setError,
 }: Props) {
   const [source, setSource] = useState('');
   const [amount, setAmount] = useState('');
-  const [category, setCategory] = useState('');
+  const [subcategoryId, setSubcategoryId] = useState('');
   const [entryDate, setEntryDate] = useState('');
 
   useEffect(() => {
     if (initial) {
       setSource(initial.source ?? '');
       setAmount(String(initial.amount ?? ''));
-      setCategory(initial.category ?? '');
+      setSubcategoryId(initial.subcategory_id ?? '');
       setEntryDate(initial.entry_date ?? '');
     } else {
-      // 新規のときはデフォルト値をセット（entryDateは当日）
       const today = new Date();
       const yyyy = today.getFullYear();
       const mm = String(today.getMonth() + 1).padStart(2, '0');
       const dd = String(today.getDate()).padStart(2, '0');
       setSource('');
       setAmount('');
-      setCategory('');
+      setSubcategoryId('');
       setEntryDate(`${yyyy}-${mm}-${dd}`);
     }
   }, [initial]);
@@ -58,23 +53,15 @@ export default function EditEntryModal({
     e.preventDefault();
     setError?.('');
     const n = Number(amount);
-    if (!source.trim()) {
-      setError?.('内容は必須です');
-      return;
-    }
+    if (!source.trim()) { setError?.('内容は必須です'); return; }
     if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
-      setError?.('金額は0以上の整数で入力してください');
-      return;
+      setError?.('金額は0以上の整数で入力してください'); return;
     }
-    if (!category.trim()) {
-      setError?.('カテゴリは必須です');
-      return;
-    }
+    if (!subcategoryId) { setError?.('カテゴリを選択してください'); return; }
     if (!/^\d{4}-\d{2}-\d{2}$/.test(entryDate)) {
-      setError?.('日付はYYYY-MM-DD形式で入力してください');
-      return;
+      setError?.('日付はYYYY-MM-DD形式で入力してください'); return;
     }
-    await onSave({ id: initial?.id, source: source.trim(), amount: n, category: category.trim(), entry_date: entryDate });
+    await onSave({ id: initial?.id, source: source.trim(), amount: n, subcategory_id: subcategoryId, entry_date: entryDate });
   };
 
   return (
@@ -100,16 +87,11 @@ export default function EditEntryModal({
             placeholder="金額（円）"
           />
         </div>
-        <div className="flex flex-col gap-1">
-          <label className="text-sm text-gray-300">カテゴリ</label>
-          <input
-            type="text"
-            value={category}
-            onChange={(e) => setCategory(e.target.value)}
-            className="rounded border border-gray-600 bg-gray-800 p-2 text-white placeholder-gray-400"
-            placeholder="カテゴリ"
-          />
-        </div>
+        <CategorySelect
+          type={type}
+          value={subcategoryId}
+          onChange={setSubcategoryId}
+        />
         <div className="flex flex-col gap-1">
           <label className="text-sm text-gray-300">日付</label>
           <input
@@ -121,17 +103,12 @@ export default function EditEntryModal({
         </div>
         {error && <p className="whitespace-pre-line text-red-400">{error}</p>}
         <div className="flex justify-end gap-2">
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded border border-gray-500 px-4 py-2 hover:bg-gray-800"
-          >
+          <button type="button" onClick={onClose}
+            className="rounded border border-gray-500 px-4 py-2 hover:bg-gray-800">
             キャンセル
           </button>
-          <button
-            type="submit"
-            className="rounded bg-blue-700 px-4 py-2 text-white hover:bg-blue-800"
-          >
+          <button type="submit"
+            className="rounded bg-blue-700 px-4 py-2 text-white hover:bg-blue-800">
             保存
           </button>
         </div>

--- a/src/components/EditEntryModal.tsx
+++ b/src/components/EditEntryModal.tsx
@@ -57,7 +57,7 @@ export default function EditEntryModal({
     if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
       setError?.('金額は0以上の整数で入力してください'); return;
     }
-    if (!subcategoryId) { setError?.('カテゴリを選択してください'); return; }
+
     if (!/^\d{4}-\d{2}-\d{2}$/.test(entryDate)) {
       setError?.('日付はYYYY-MM-DD形式で入力してください'); return;
     }

--- a/src/lib/supabaseServerClient.ts
+++ b/src/lib/supabaseServerClient.ts
@@ -12,9 +12,13 @@ export async function createSupabaseServerClient() {
           return cookieStore.getAll();
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) =>
-            cookieStore.set(name, value, options)
-          );
+          try {
+            cookiesToSet.forEach(({ name, value, options }) =>
+              cookieStore.set(name, value, options)
+            );
+          } catch {
+            // Server Component では書き込み不可。Middleware がセッション更新を担う
+          }
         },
       },
     }

--- a/src/lib/validation/category.ts
+++ b/src/lib/validation/category.ts
@@ -1,0 +1,11 @@
+import { z } from 'zod';
+
+export const CategoryCreateSchema = z.object({
+  name: z.string().trim().min(1, 'カテゴリ名は必須です').max(30, '30文字以内'),
+  type: z.enum(['income', 'expense']),
+});
+
+export const SubcategoryCreateSchema = z.object({
+  category_id: z.string().uuid('無効なカテゴリIDです'),
+  name: z.string().trim().min(1, 'サブカテゴリ名は必須です').max(30, '30文字以内'),
+});

--- a/src/lib/validation/expense.ts
+++ b/src/lib/validation/expense.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 import { sourceSchema, amountSchema, entryDateSchema } from './common';
 
-const subcategoryIdSchema = z.string().uuid({ message: 'カテゴリを選択してください' });
+const subcategoryIdSchema = z.string().uuid({ message: '無効なカテゴリIDです' });
+const optionalSubcategoryId = subcategoryIdSchema.optional().or(z.literal('').transform(() => undefined));
 
 export const ExpenseCreateSchema = z.object({
   source: sourceSchema,
   amount: amountSchema,
-  subcategory_id: subcategoryIdSchema,
+  subcategory_id: optionalSubcategoryId,
   entry_date: entryDateSchema,
 });
 
@@ -14,7 +15,7 @@ export const ExpenseUpdateSchema = z.object({
   id: z.coerce.number().int().positive(),
   source: sourceSchema.optional(),
   amount: amountSchema.optional(),
-  subcategory_id: subcategoryIdSchema.optional(),
+  subcategory_id: optionalSubcategoryId,
   entry_date: entryDateSchema.optional(),
 }).refine(obj =>
   obj.source !== undefined || obj.amount !== undefined ||

--- a/src/lib/validation/expense.ts
+++ b/src/lib/validation/expense.ts
@@ -1,19 +1,23 @@
 import { z } from 'zod';
-import { sourceSchema, amountSchema, categorySchema, entryDateSchema } from './common';
+import { sourceSchema, amountSchema, entryDateSchema } from './common';
 
-// 新規登録スキーマ
+const subcategoryIdSchema = z.string().uuid({ message: 'カテゴリを選択してください' });
+
 export const ExpenseCreateSchema = z.object({
   source: sourceSchema,
   amount: amountSchema,
-  category: categorySchema,
+  subcategory_id: subcategoryIdSchema,
   entry_date: entryDateSchema,
 });
 
-// 更新スキーマ
 export const ExpenseUpdateSchema = z.object({
   id: z.coerce.number().int().positive(),
   source: sourceSchema.optional(),
   amount: amountSchema.optional(),
-}).refine(obj => obj.source !== undefined || obj.amount !== undefined, {
-  message: '更新項目がありません',
-});
+  subcategory_id: subcategoryIdSchema.optional(),
+  entry_date: entryDateSchema.optional(),
+}).refine(obj =>
+  obj.source !== undefined || obj.amount !== undefined ||
+  obj.subcategory_id !== undefined || obj.entry_date !== undefined,
+  { message: '更新項目がありません' }
+);

--- a/src/lib/validation/income.ts
+++ b/src/lib/validation/income.ts
@@ -1,12 +1,13 @@
 import { z } from 'zod';
 import { sourceSchema, amountSchema, entryDateSchema } from './common';
 
-const subcategoryIdSchema = z.string().uuid({ message: 'カテゴリを選択してください' });
+const subcategoryIdSchema = z.string().uuid({ message: '無効なカテゴリIDです' });
+const optionalSubcategoryId = subcategoryIdSchema.optional().or(z.literal('').transform(() => undefined));
 
 export const IncomeCreateSchema = z.object({
   source: sourceSchema,
   amount: amountSchema,
-  subcategory_id: subcategoryIdSchema,
+  subcategory_id: optionalSubcategoryId,
   entry_date: entryDateSchema,
 });
 
@@ -15,7 +16,7 @@ export const IncomeUpdateSchema = z
     id: z.coerce.number().int().positive(),
     source: sourceSchema.optional(),
     amount: amountSchema.optional(),
-    subcategory_id: subcategoryIdSchema.optional(),
+    subcategory_id: optionalSubcategoryId,
     entry_date: entryDateSchema.optional(),
   })
   .refine(obj =>

--- a/src/lib/validation/income.ts
+++ b/src/lib/validation/income.ts
@@ -1,10 +1,12 @@
 import { z } from 'zod';
-import { sourceSchema, amountSchema, categorySchema, entryDateSchema } from './common';
+import { sourceSchema, amountSchema, entryDateSchema } from './common';
+
+const subcategoryIdSchema = z.string().uuid({ message: 'カテゴリを選択してください' });
 
 export const IncomeCreateSchema = z.object({
   source: sourceSchema,
   amount: amountSchema,
-  category: categorySchema,
+  subcategory_id: subcategoryIdSchema,
   entry_date: entryDateSchema,
 });
 
@@ -13,7 +15,11 @@ export const IncomeUpdateSchema = z
     id: z.coerce.number().int().positive(),
     source: sourceSchema.optional(),
     amount: amountSchema.optional(),
+    subcategory_id: subcategoryIdSchema.optional(),
+    entry_date: entryDateSchema.optional(),
   })
-  .refine(obj => obj.source !== undefined || obj.amount !== undefined, {
-    message: '更新項目がありません',
-  });
+  .refine(obj =>
+    obj.source !== undefined || obj.amount !== undefined ||
+    obj.subcategory_id !== undefined || obj.entry_date !== undefined,
+    { message: '更新項目がありません' }
+  );

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -2,4 +2,5 @@
 export * from './common';
 export * from './income';
 export * from './household';
+export * from './category';
 // expense 追加時はここに export * from './expense';

--- a/supabase/migrations/20260501000000_add_category_master.sql
+++ b/supabase/migrations/20260501000000_add_category_master.sql
@@ -1,0 +1,230 @@
+-- ─── categories テーブル ─────────────────────────────────────────────────────
+create table if not exists public.categories (
+  id         uuid primary key default gen_random_uuid(),
+  name       text not null,
+  type       text not null check (type in ('income', 'expense')),
+  user_id    uuid references auth.users(id) on delete cascade, -- NULL = マスタ
+  sort_order integer not null default 0,
+  created_at timestamptz not null default now()
+);
+
+-- ─── subcategories テーブル ──────────────────────────────────────────────────
+create table if not exists public.subcategories (
+  id          uuid primary key default gen_random_uuid(),
+  category_id uuid not null references public.categories(id) on delete cascade,
+  name        text not null,
+  user_id     uuid references auth.users(id) on delete cascade, -- NULL = マスタ
+  sort_order  integer not null default 0,
+  created_at  timestamptz not null default now()
+);
+
+create index if not exists idx_categories_type    on public.categories (type);
+create index if not exists idx_categories_user_id on public.categories (user_id);
+create index if not exists idx_subcategories_category_id on public.subcategories (category_id);
+
+-- ─── RLS: categories ─────────────────────────────────────────────────────────
+alter table public.categories enable row level security;
+
+create policy categories_select on public.categories for select to authenticated
+  using (user_id is null or user_id = auth.uid());
+
+create policy categories_insert on public.categories for insert to authenticated
+  with check (user_id = auth.uid());
+
+create policy categories_update on public.categories for update to authenticated
+  using (user_id = auth.uid());
+
+create policy categories_delete on public.categories for delete to authenticated
+  using (user_id = auth.uid());
+
+-- ─── RLS: subcategories ──────────────────────────────────────────────────────
+alter table public.subcategories enable row level security;
+
+create policy subcategories_select on public.subcategories for select to authenticated
+  using (user_id is null or user_id = auth.uid());
+
+create policy subcategories_insert on public.subcategories for insert to authenticated
+  with check (user_id = auth.uid());
+
+create policy subcategories_update on public.subcategories for update to authenticated
+  using (user_id = auth.uid());
+
+create policy subcategories_delete on public.subcategories for delete to authenticated
+  using (user_id = auth.uid());
+
+-- ─── マスタデータ投入（MoneyForward ME 準拠） ────────────────────────────────
+
+-- 支出カテゴリ
+with ins as (
+  insert into public.categories (name, type, sort_order) values
+    ('食費',         'expense',  1),
+    ('日用品',       'expense',  2),
+    ('交通費',       'expense',  3),
+    ('趣味・娯楽',   'expense',  4),
+    ('衣服・美容',   'expense',  5),
+    ('健康・医療',   'expense',  6),
+    ('通信費',       'expense',  7),
+    ('教養・教育',   'expense',  8),
+    ('住宅',         'expense',  9),
+    ('水道・光熱費', 'expense', 10),
+    ('自動車',       'expense', 11),
+    ('保険',         'expense', 12),
+    ('税・社会保障', 'expense', 13),
+    ('特別な支出',   'expense', 14),
+    ('交際費',       'expense', 15),
+    ('現金・カード', 'expense', 16),
+    ('その他',       'expense', 17)
+  returning id, name
+)
+insert into public.subcategories (category_id, name, sort_order)
+select c.id, s.name, s.sort_order from (
+  values
+    ('食費',         '食料品',           1),
+    ('食費',         '外食',             2),
+    ('食費',         'カフェ・喫茶',     3),
+    ('食費',         'アルコール',       4),
+    ('日用品',       '日用品',           1),
+    ('日用品',       'ドラッグストア',   2),
+    ('日用品',       'ペット',           3),
+    ('日用品',       'タバコ',           4),
+    ('交通費',       '電車・バス',       1),
+    ('交通費',       'タクシー',         2),
+    ('交通費',       '飛行機',           3),
+    ('交通費',       '高速道路',         4),
+    ('交通費',       '駐車場',           5),
+    ('趣味・娯楽',   'アウトドア',       1),
+    ('趣味・娯楽',   'スポーツ',         2),
+    ('趣味・娯楽',   '映画・音楽・ゲーム', 3),
+    ('趣味・娯楽',   '本・雑誌',         4),
+    ('趣味・娯楽',   '旅行',             5),
+    ('趣味・娯楽',   'その他趣味',       6),
+    ('衣服・美容',   '衣類',             1),
+    ('衣服・美容',   'アクセサリー',     2),
+    ('衣服・美容',   '美容院',           3),
+    ('衣服・美容',   '化粧品',           4),
+    ('健康・医療',   '病院',             1),
+    ('健康・医療',   '薬',               2),
+    ('健康・医療',   'フィットネス',     3),
+    ('通信費',       '携帯電話',         1),
+    ('通信費',       'インターネット',   2),
+    ('通信費',       '放送視聴料',       3),
+    ('教養・教育',   '書籍',             1),
+    ('教養・教育',   '学費',             2),
+    ('教養・教育',   '塾・習い事',       3),
+    ('住宅',         '家賃',             1),
+    ('住宅',         '住宅ローン',       2),
+    ('住宅',         '管理費・修繕積立', 3),
+    ('住宅',         '地代',             4),
+    ('水道・光熱費', '電気代',           1),
+    ('水道・光熱費', 'ガス代',           2),
+    ('水道・光熱費', '水道代',           3),
+    ('自動車',       'ガソリン',         1),
+    ('自動車',       '自動車ローン',     2),
+    ('自動車',       '駐車場',           3),
+    ('自動車',       '高速道路',         4),
+    ('自動車',       '車検・整備',       5),
+    ('自動車',       '自動車税',         6),
+    ('保険',         '生命保険',         1),
+    ('保険',         '医療保険',         2),
+    ('保険',         '火災保険',         3),
+    ('保険',         '自動車保険',       4),
+    ('保険',         '学資保険',         5),
+    ('税・社会保障', '所得税',           1),
+    ('税・社会保障', '住民税',           2),
+    ('税・社会保障', '社会保険料',       3),
+    ('税・社会保障', '固定資産税',       4),
+    ('税・社会保障', 'ふるさと納税',     5),
+    ('特別な支出',   '冠婚葬祭',         1),
+    ('特別な支出',   'プレゼント',       2),
+    ('特別な支出',   '家電・家具',       3),
+    ('交際費',       '交際費',           1),
+    ('現金・カード', 'ATM引出し',        1),
+    ('現金・カード', 'クレジット引き落とし', 2),
+    ('その他',       'その他',           1)
+) as s(cat_name, name, sort_order)
+join ins as c on c.name = s.cat_name;
+
+-- 収入カテゴリ
+with ins as (
+  insert into public.categories (name, type, sort_order) values
+    ('給与・賞与',   'income', 1),
+    ('事業・副業',   'income', 2),
+    ('年金・補助',   'income', 3),
+    ('贈与・祝い',   'income', 4),
+    ('不労所得',     'income', 5),
+    ('その他収入',   'income', 6)
+  returning id, name
+)
+insert into public.subcategories (category_id, name, sort_order)
+select c.id, s.name, s.sort_order from (
+  values
+    ('給与・賞与', '給与',     1),
+    ('給与・賞与', '賞与',     2),
+    ('事業・副業', '事業収入', 1),
+    ('事業・副業', '副業収入', 2),
+    ('年金・補助', '年金',     1),
+    ('年金・補助', '保険受取', 2),
+    ('年金・補助', '補助金',   3),
+    ('贈与・祝い', '贈与',     1),
+    ('贈与・祝い', 'お祝い',   2),
+    ('不労所得',   '配当',     1),
+    ('不労所得',   '利子',     2),
+    ('不労所得',   '家賃収入', 3),
+    ('その他収入', 'その他',   1)
+) as s(cat_name, name, sort_order)
+join ins as c on c.name = s.cat_name;
+
+-- ─── income / expense に subcategory_id を追加 ───────────────────────────────
+alter table public.income  add column if not exists subcategory_id uuid references public.subcategories(id);
+alter table public.expense add column if not exists subcategory_id uuid references public.subcategories(id);
+
+create index if not exists idx_income_subcategory_id  on public.income  (subcategory_id);
+create index if not exists idx_expense_subcategory_id on public.expense (subcategory_id);
+
+-- ─── 既存データの移行（フリーテキスト → subcategory_id） ──────────────────────
+-- 収入
+update public.income i set subcategory_id = s.id
+from public.subcategories s
+join public.categories c on c.id = s.category_id
+where c.type = 'income' and (
+  (i.category = '給与'   and c.name = '給与・賞与' and s.name = '給与') or
+  (i.category = '賞与'   and c.name = '給与・賞与' and s.name = '賞与') or
+  (i.category = '副業'   and c.name = '事業・副業' and s.name = '副業収入') or
+  (i.category = 'その他' and c.name = 'その他収入' and s.name = 'その他')
+);
+-- 未マッチ行は「その他収入 / その他」にフォールバック
+update public.income set subcategory_id = (
+  select s.id from public.subcategories s
+  join public.categories c on c.id = s.category_id
+  where c.name = 'その他収入' and s.name = 'その他' and c.user_id is null
+  limit 1
+) where subcategory_id is null;
+
+-- 支出
+update public.expense e set subcategory_id = s.id
+from public.subcategories s
+join public.categories c on c.id = s.category_id
+where c.type = 'expense' and (
+  (e.category = '食費'   and c.name = '食費'         and s.name = '食料品') or
+  (e.category = '外食費' and c.name = '食費'         and s.name = '外食') or
+  (e.category = '住居費' and c.name = '住宅'         and s.name = '家賃') or
+  (e.category = '光熱費' and c.name = '水道・光熱費' and s.name = '電気代') or
+  (e.category = '交通費' and c.name = '交通費'       and s.name = '電車・バス') or
+  (e.category = '通信費' and c.name = '通信費'       and s.name = '携帯電話') or
+  (e.category = '娯楽費' and c.name = '趣味・娯楽'   and s.name = 'その他趣味') or
+  (e.category = '衣服費' and c.name = '衣服・美容'   and s.name = '衣類') or
+  (e.category = '医療費' and c.name = '健康・医療'   and s.name = '病院')
+);
+-- 未マッチ行は「その他 / その他」にフォールバック
+update public.expense set subcategory_id = (
+  select s.id from public.subcategories s
+  join public.categories c on c.id = s.category_id
+  where c.name = 'その他' and s.name = 'その他' and c.type = 'expense' and c.user_id is null
+  limit 1
+) where subcategory_id is null;
+
+-- ─── 旧 category カラムを削除 ────────────────────────────────────────────────
+alter table public.income  drop column if exists category;
+alter table public.expense drop column if exists category;
+
+-- ─── income/expense の RLS も subcategory_id を考慮（参照のみ、既存ポリシーは変更なし） ──

--- a/supabase/migrations/20260501000001_add_miscellaneous_category.sql
+++ b/supabase/migrations/20260501000001_add_miscellaneous_category.sql
@@ -1,0 +1,24 @@
+-- 未分類カテゴリをマスタに追加（income / expense 両方）
+do $$
+declare
+  cat_id uuid;
+begin
+  -- expense: 未分類
+  insert into public.categories (name, type, sort_order)
+  values ('未分類', 'expense', 99)
+  returning id into cat_id;
+  insert into public.subcategories (category_id, name, sort_order)
+  values (cat_id, '未分類', 1);
+
+  -- income: 未分類
+  insert into public.categories (name, type, sort_order)
+  values ('未分類', 'income', 99)
+  returning id into cat_id;
+  insert into public.subcategories (category_id, name, sort_order)
+  values (cat_id, '未分類', 1);
+end;
+$$;
+
+-- subcategory_id を nullable に変更（任意入力対応）
+alter table public.income  alter column subcategory_id drop not null;
+alter table public.expense alter column subcategory_id drop not null;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -4,7 +4,6 @@
 -- ============================================================
 
 -- デモユーザーを auth.users に挿入
--- handle_new_user トリガーが profiles も自動作成する
 INSERT INTO auth.users (
   id, email, encrypted_password, email_confirmed_at,
   created_at, updated_at, aud, role,
@@ -20,62 +19,72 @@ VALUES (
   '{"display_name":"デモユーザー"}'
 ) ON CONFLICT (id) DO NOTHING;
 
--- ─── 収入データ（3ヶ月分） ────────────────────────────────────────────────────
-INSERT INTO public.income (source, amount, category, entry_date, user_id) VALUES
+-- ─── 収入データ（subcategory_id をサブカテゴリ名で逆引き） ──────────────────
+insert into public.income (source, amount, subcategory_id, entry_date, user_id)
+select s.source, s.amount, sub.id, s.entry_date, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'::uuid
+from (values
   -- 2026年3月
-  ('月給（3月分）',    320000, '給与',   '2026-03-25', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('フリーランス案件', 85000,  '副業',   '2026-03-15', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('メルカリ売上',     12000,  'その他', '2026-03-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('月給（3月分）',    320000, '給与',     '給与・賞与', '2026-03-25'),
+  ('フリーランス案件', 85000,  '副業収入', '事業・副業', '2026-03-15'),
+  ('メルカリ売上',     12000,  'その他',   'その他収入', '2026-03-10'),
   -- 2026年4月
-  ('月給（4月分）',    320000, '給与',   '2026-04-25', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('フリーランス案件', 120000, '副業',   '2026-04-18', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('春季賞与',         180000, '賞与',   '2026-04-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('メルカリ売上',     8500,   'その他', '2026-04-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('月給（4月分）',    320000, '給与',     '給与・賞与', '2026-04-25'),
+  ('フリーランス案件', 120000, '副業収入', '事業・副業', '2026-04-18'),
+  ('春季賞与',         180000, '賞与',     '給与・賞与', '2026-04-10'),
+  ('メルカリ売上',     8500,   'その他',   'その他収入', '2026-04-05'),
   -- 2026年5月
-  ('月給（5月分）',    320000, '給与',   '2026-05-25', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('フリーランス案件', 95000,  '副業',   '2026-05-12', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  ('月給（5月分）',    320000, '給与',     '給与・賞与', '2026-05-25'),
+  ('フリーランス案件', 95000,  '副業収入', '事業・副業', '2026-05-12')
+) as s(source, amount, sub_name, cat_name, entry_date)
+join public.subcategories sub on sub.name = s.sub_name and sub.user_id is null
+join public.categories cat on cat.id = sub.category_id and cat.name = s.cat_name and cat.user_id is null;
 
--- ─── 支出データ（3ヶ月分） ────────────────────────────────────────────────────
-INSERT INTO public.expense (source, amount, category, entry_date, user_id) VALUES
+-- ─── 支出データ ───────────────────────────────────────────────────────────────
+insert into public.expense (source, amount, subcategory_id, entry_date, user_id)
+select s.source, s.amount, sub.id, s.entry_date, 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'::uuid
+from (values
   -- 2026年3月
-  ('家賃',           95000, '住居費',  '2026-03-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週1）', 6800,  '食費',   '2026-03-03', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週2）', 7200,  '食費',   '2026-03-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週3）', 6500,  '食費',   '2026-03-17', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週4）', 7800,  '食費',   '2026-03-24', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('ランチ代',        4500,  '外食費', '2026-03-12', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('飲み会',          8000,  '外食費', '2026-03-20', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('電気代',          8200,  '光熱費', '2026-03-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('ガス代',          3800,  '光熱費', '2026-03-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('交通費（定期）',  12000, '交通費', '2026-03-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スマホ代',        5500,  '通信費', '2026-03-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('映画・配信',      3200,  '娯楽費', '2026-03-15', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('病院',            2800,  '医療費', '2026-03-22', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('家賃',           95000, '家賃',           '住宅',         '2026-03-01'),
+  ('スーパー（週1）', 6800, '食料品',         '食費',         '2026-03-03'),
+  ('スーパー（週2）', 7200, '食料品',         '食費',         '2026-03-10'),
+  ('スーパー（週3）', 6500, '食料品',         '食費',         '2026-03-17'),
+  ('スーパー（週4）', 7800, '食料品',         '食費',         '2026-03-24'),
+  ('ランチ代',        4500, '外食',           '食費',         '2026-03-12'),
+  ('飲み会',          8000, '外食',           '食費',         '2026-03-20'),
+  ('電気代',          8200, '電気代',         '水道・光熱費', '2026-03-05'),
+  ('ガス代',          3800, 'ガス代',         '水道・光熱費', '2026-03-05'),
+  ('交通費（定期）', 12000, '電車・バス',     '交通費',       '2026-03-01'),
+  ('スマホ代',        5500, '携帯電話',       '通信費',       '2026-03-10'),
+  ('映画・配信',      3200, '映画・音楽・ゲーム', '趣味・娯楽', '2026-03-15'),
+  ('病院',            2800, '病院',           '健康・医療',   '2026-03-22'),
   -- 2026年4月
-  ('家賃',           95000, '住居費',  '2026-04-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週1）', 7100,  '食費',   '2026-04-07', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週2）', 6900,  '食費',   '2026-04-14', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週3）', 8200,  '食費',   '2026-04-21', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週4）', 6600,  '食費',   '2026-04-28', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('花見',           15000, '外食費',  '2026-04-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('ランチ代',        5200,  '外食費', '2026-04-18', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('電気代',          7500,  '光熱費', '2026-04-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('ガス代',          3200,  '光熱費', '2026-04-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('交通費（定期）',  12000, '交通費', '2026-04-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スマホ代',        5500,  '通信費', '2026-04-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('春服',           22000, '衣服費',  '2026-04-12', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('映画・配信',      3200,  '娯楽費', '2026-04-15', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('ジム入会',        8000,  '娯楽費', '2026-04-20', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
+  ('家賃',           95000, '家賃',           '住宅',         '2026-04-01'),
+  ('スーパー（週1）', 7100, '食料品',         '食費',         '2026-04-07'),
+  ('スーパー（週2）', 6900, '食料品',         '食費',         '2026-04-14'),
+  ('スーパー（週3）', 8200, '食料品',         '食費',         '2026-04-21'),
+  ('スーパー（週4）', 6600, '食料品',         '食費',         '2026-04-28'),
+  ('花見',           15000, '外食',           '食費',         '2026-04-05'),
+  ('ランチ代',        5200, '外食',           '食費',         '2026-04-18'),
+  ('電気代',          7500, '電気代',         '水道・光熱費', '2026-04-05'),
+  ('ガス代',          3200, 'ガス代',         '水道・光熱費', '2026-04-05'),
+  ('交通費（定期）', 12000, '電車・バス',     '交通費',       '2026-04-01'),
+  ('スマホ代',        5500, '携帯電話',       '通信費',       '2026-04-10'),
+  ('春服',           22000, '衣類',           '衣服・美容',   '2026-04-12'),
+  ('映画・配信',      3200, '映画・音楽・ゲーム', '趣味・娯楽', '2026-04-15'),
+  ('ジム入会',        8000, 'フィットネス',   '健康・医療',   '2026-04-20'),
   -- 2026年5月
-  ('家賃',           95000, '住居費',  '2026-05-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週1）', 6700,  '食費',   '2026-05-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週2）', 7300,  '食費',   '2026-05-12', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週3）', 6900,  '食費',   '2026-05-19', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スーパー（週4）', 7500,  '食費',   '2026-05-26', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('GW旅行',         45000, '娯楽費',  '2026-05-03', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('ランチ代',        4800,  '外食費', '2026-05-14', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('電気代',          6800,  '光熱費', '2026-05-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('ガス代',          2900,  '光熱費', '2026-05-05', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('交通費（定期）',  12000, '交通費', '2026-05-01', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('スマホ代',        5500,  '通信費', '2026-05-10', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'),
-  ('映画・配信',      3200,  '娯楽費', '2026-05-15', 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee');
+  ('家賃',           95000, '家賃',           '住宅',         '2026-05-01'),
+  ('スーパー（週1）', 6700, '食料品',         '食費',         '2026-05-05'),
+  ('スーパー（週2）', 7300, '食料品',         '食費',         '2026-05-12'),
+  ('スーパー（週3）', 6900, '食料品',         '食費',         '2026-05-19'),
+  ('スーパー（週4）', 7500, '食料品',         '食費',         '2026-05-26'),
+  ('GW旅行',         45000, '旅行',           '趣味・娯楽',   '2026-05-03'),
+  ('ランチ代',        4800, '外食',           '食費',         '2026-05-14'),
+  ('電気代',          6800, '電気代',         '水道・光熱費', '2026-05-05'),
+  ('ガス代',          2900, 'ガス代',         '水道・光熱費', '2026-05-05'),
+  ('交通費（定期）', 12000, '電車・バス',     '交通費',       '2026-05-01'),
+  ('スマホ代',        5500, '携帯電話',       '通信費',       '2026-05-10'),
+  ('映画・配信',      3200, '映画・音楽・ゲーム', '趣味・娯楽', '2026-05-15')
+) as s(source, amount, sub_name, cat_name, entry_date)
+join public.subcategories sub on sub.name = s.sub_name and sub.user_id is null
+join public.categories cat on cat.id = sub.category_id and cat.name = s.cat_name and cat.user_id is null;


### PR DESCRIPTION
## Summary

- MoneyForward ME準拠のカテゴリマスタを導入（支出17分類・収入6分類・サブカテゴリ75件）
- ユーザーが独自カテゴリ・サブカテゴリを追加可能
- income/expense の `category` テキストを `subcategory_id` FK に変更
- 既存データはマスタに自動マッピング（未マッチは「その他」にフォールバック）
- 収入・支出フォームを2段セレクト（メイン→サブ）＋インライン新規作成UIに置き換え
- seed.sql をsubcategory_id対応に更新

## Changes

**DB**
- `categories` / `subcategories` テーブル追加・RLS設定
- `income.category` / `expense.category` → `subcategory_id` FK に移行・旧カラム削除

**API**
- `GET /api/categories?type=income|expense` — マスタ+独自カテゴリ取得
- `POST /api/categories` — 独自カテゴリ作成
- `POST /api/subcategories` — 独自サブカテゴリ作成

**UI**
- `CategorySelect` コンポーネント（2段セレクト＋インライン新規作成）
- `EditEntryModal` を CategorySelect に統合

## Test plan

- [ ] 収入・支出の新規追加でカテゴリセレクトが表示されることを確認
- [ ] メインカテゴリ選択後にサブカテゴリが絞り込まれることを確認
- [ ] 「カテゴリを新規作成」でインライン入力が出ることを確認
- [ ] 作成したカスタムカテゴリ（★マーク）が一覧に追加されることを確認
- [ ] 編集時に既存のカテゴリが選択済みで表示されることを確認

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)