### PR TITLE
fix: supabase db push の廃止された --project-ref フラグを修正

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -17,8 +17,13 @@ jobs:
         with:
           version: latest
 
+      - name: Link Supabase project
+        run: supabase link --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+
       - name: Apply migrations to production
-        run: supabase db push --project-ref ${{ vars.SUPABASE_PROJECT_REF }}
+        run: supabase db push
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}


### PR DESCRIPTION
supabase CLI の新バージョンで db push から --project-ref が削除されたため、
先に supabase link でプロジェクトをリンクしてから db push を実行する方式に変更。

https://claude.ai/code/session_014Yu2eZgkpvHXcVqDeLayJu