### PR TITLE
fix: Supabase CLIフラグ修正・精算キャンセルRLSバグ修正・型定義更新

### DIFF
--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -14,78 +14,358 @@ export type Database = {
   }
   public: {
     Tables: {
+      categories: {
+        Row: {
+          created_at: string
+          id: string
+          name: string
+          sort_order: number
+          type: string
+          user_id: string | null
+        }
+        Insert: {
+          created_at?: string
+          id?: string
+          name: string
+          sort_order?: number
+          type: string
+          user_id?: string | null
+        }
+        Update: {
+          created_at?: string
+          id?: string
+          name?: string
+          sort_order?: number
+          type?: string
+          user_id?: string | null
+        }
+        Relationships: []
+      }
       expense: {
         Row: {
           amount: number
-          category: string
           created_at: string
-          entry_date: string
+          entry_date: string | null
+          household_id: string | null
           id: number
+          needs_settlement: boolean
+          owner: string
           source: string
+          subcategory_id: string | null
           updated_at: string
           user_id: string | null
         }
         Insert: {
           amount: number
-          category?: string
           created_at?: string
-          entry_date?: string
+          entry_date?: string | null
+          household_id?: string | null
           id?: number
+          needs_settlement?: boolean
+          owner?: string
           source: string
+          subcategory_id?: string | null
           updated_at?: string
           user_id?: string | null
         }
         Update: {
           amount?: number
-          category?: string
           created_at?: string
-          entry_date?: string
+          entry_date?: string | null
+          household_id?: string | null
           id?: number
+          needs_settlement?: boolean
+          owner?: string
           source?: string
+          subcategory_id?: string | null
           updated_at?: string
           user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "expense_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "expense_subcategory_id_fkey"
+            columns: ["subcategory_id"]
+            isOneToOne: false
+            referencedRelation: "subcategories"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      household_invitations: {
+        Row: {
+          created_at: string
+          created_by: string
+          expires_at: string | null
+          household_id: string
+          id: string
+          used_at: string | null
+          used_by: string | null
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          expires_at?: string | null
+          household_id: string
+          id?: string
+          used_at?: string | null
+          used_by?: string | null
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          expires_at?: string | null
+          household_id?: string
+          id?: string
+          used_at?: string | null
+          used_by?: string | null
+        }
+        Relationships: []
+      }
+      household_members: {
+        Row: {
+          household_id: string
+          joined_at: string
+          role: string
+          user_id: string
+        }
+        Insert: {
+          household_id: string
+          joined_at?: string
+          role?: string
+          user_id: string
+        }
+        Update: {
+          household_id?: string
+          joined_at?: string
+          role?: string
+          user_id?: string
+        }
+        Relationships: []
+      }
+      households: {
+        Row: {
+          created_at: string
+          created_by: string
+          id: string
+          name: string
+        }
+        Insert: {
+          created_at?: string
+          created_by: string
+          id?: string
+          name: string
+        }
+        Update: {
+          created_at?: string
+          created_by?: string
+          id?: string
+          name?: string
         }
         Relationships: []
       }
       income: {
         Row: {
           amount: number
-          category: string
           created_at: string
-          entry_date: string
+          entry_date: string | null
+          household_id: string | null
           id: number
+          needs_settlement: boolean
+          owner: string
           source: string
+          subcategory_id: string | null
           updated_at: string
           user_id: string | null
         }
         Insert: {
-          amount?: number
-          category?: string
+          amount: number
           created_at?: string
-          entry_date?: string
+          entry_date?: string | null
+          household_id?: string | null
           id?: number
+          needs_settlement?: boolean
+          owner?: string
           source: string
+          subcategory_id?: string | null
           updated_at?: string
           user_id?: string | null
         }
         Update: {
           amount?: number
-          category?: string
           created_at?: string
-          entry_date?: string
+          entry_date?: string | null
+          household_id?: string | null
           id?: number
+          needs_settlement?: boolean
+          owner?: string
           source?: string
+          subcategory_id?: string | null
           updated_at?: string
           user_id?: string | null
         }
+        Relationships: [
+          {
+            foreignKeyName: "income_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "income_subcategory_id_fkey"
+            columns: ["subcategory_id"]
+            isOneToOne: false
+            referencedRelation: "subcategories"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      profiles: {
+        Row: {
+          created_at: string
+          display_name: string
+          updated_at: string
+          user_id: string
+        }
+        Insert: {
+          created_at?: string
+          display_name: string
+          updated_at?: string
+          user_id: string
+        }
+        Update: {
+          created_at?: string
+          display_name?: string
+          updated_at?: string
+          user_id?: string
+        }
         Relationships: []
+      }
+      settlement_items: {
+        Row: {
+          id: string
+          item_id: number
+          item_type: string
+          settlement_id: string
+        }
+        Insert: {
+          id?: string
+          item_id: number
+          item_type: string
+          settlement_id: string
+        }
+        Update: {
+          id?: string
+          item_id?: number
+          item_type?: string
+          settlement_id?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "settlement_items_settlement_id_fkey"
+            columns: ["settlement_id"]
+            isOneToOne: false
+            referencedRelation: "settlements"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      settlements: {
+        Row: {
+          cancelled_at: string | null
+          created_at: string
+          household_id: string
+          id: string
+          payments: Json
+          settled_at: string
+          split_ratios: Json
+          total_amount: number
+        }
+        Insert: {
+          cancelled_at?: string | null
+          created_at?: string
+          household_id: string
+          id?: string
+          payments: Json
+          settled_at?: string
+          split_ratios: Json
+          total_amount: number
+        }
+        Update: {
+          cancelled_at?: string | null
+          created_at?: string
+          household_id?: string
+          id?: string
+          payments?: Json
+          settled_at?: string
+          split_ratios?: Json
+          total_amount?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "settlements_household_id_fkey"
+            columns: ["household_id"]
+            isOneToOne: false
+            referencedRelation: "households"
+            referencedColumns: ["id"]
+          }
+        ]
+      }
+      subcategories: {
+        Row: {
+          category_id: string
+          created_at: string
+          id: string
+          name: string
+          sort_order: number
+          user_id: string | null
+        }
+        Insert: {
+          category_id: string
+          created_at?: string
+          id?: string
+          name: string
+          sort_order?: number
+          user_id?: string | null
+        }
+        Update: {
+          category_id?: string
+          created_at?: string
+          id?: string
+          name?: string
+          sort_order?: number
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "subcategories_category_id_fkey"
+            columns: ["category_id"]
+            isOneToOne: false
+            referencedRelation: "categories"
+            referencedColumns: ["id"]
+          }
+        ]
       }
     }
     Views: {
       [_ in never]: never
     }
     Functions: {
-      [_ in never]: never
+      get_my_household_id: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
+      get_my_household_role: {
+        Args: Record<PropertyKey, never>
+        Returns: string
+      }
     }
     Enums: {
       [_ in never]: never

--- a/supabase/migrations/20260511000001_add_settlements_update_policy.sql
+++ b/supabase/migrations/20260511000001_add_settlements_update_policy.sql
@@ -1,0 +1,10 @@
+-- settlements の UPDATE ポリシーが欠落していたため追加
+-- PATCH /api/settlement/[id] でキャンセル時に cancelled_at が更新できない問題を修正
+
+CREATE POLICY "settlements_update" ON settlements
+  FOR UPDATE TO authenticated
+  USING (
+    household_id IN (
+      SELECT household_id FROM household_members WHERE user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `supabase db push --project-ref` の廃止フラグを修正（`supabase link` → `db push` に変更）
- `settlements` テーブルの UPDATE RLS ポリシー欠落を修正（精算キャンセルがサイレント失敗していた）
- `database.types.ts` を現在のスキーマに合わせて更新（`category` カラム削除、`subcategory_id` / `owner` / `needs_settlement` / 各テーブル追加）

## 変更詳細

### CI ワークフロー修正 (`.github/workflows/migrate.yml`)
旧: `supabase db push --project-ref ${{ vars.SUPABASE_PROJECT_REF }}`
新: `supabase link --project-ref` → `supabase db push`

### RLS ポリシー追加 (`supabase/migrations/20260511000001_add_settlements_update_policy.sql`)
`settlements` に UPDATE ポリシーがなかったため、`PATCH /api/settlement/[id]` で `cancelled_at` が更新されずキャンセルが無音で失敗していた。世帯メンバーに UPDATE 権限を付与するポリシーを追加。

### 型定義更新 (`src/types/database.types.ts`)
マイグレーションで削除済みの `category` カラムが残存、新規テーブル（`settlements` / `settlement_items` / `households` / `profiles` 等）が未定義だった状態を修正。

## Test plan

- [ ] CI ワークフローが `supabase db push` で正常終了することを確認
- [ ] 精算キャンセル (`PATCH /api/settlement/[id]`) 後に `cancelled_at` がセットされることを確認
- [ ] TypeScript ビルドエラーがないことを確認

https://claude.ai/code/session_014Yu2eZgkpvHXcVqDeLayJu
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Yu2eZgkpvHXcVqDeLayJu)_