### PR TITLE
fix: 世帯解散でカスケード削除がRLSにブロックされる問題を修正

### DIFF
--- a/__tests__/api/households.test.ts
+++ b/__tests__/api/households.test.ts
@@ -181,11 +181,14 @@ describe('DELETE /api/households', () => {
   });
 
   it('オーナーは世帯を解散できる', async () => {
-    mockFrom
-      .mockImplementationOnce(() =>
-        makeQueryMock({ data: { household_id: HOUSEHOLD_ID, role: 'owner' }, error: null })
-      )
-      .mockImplementationOnce(() => makeQueryMock({ error: null }));
+    // membership 取得: server client
+    mockFrom.mockImplementationOnce(() =>
+      makeQueryMock({ data: { household_id: HOUSEHOLD_ID, role: 'owner' }, error: null })
+    );
+    // households DELETE: admin client（カスケード先のRLSをバイパスするため）
+    vi.mocked(supabaseAdmin.from).mockImplementationOnce(
+      () => makeQueryMock({ error: null }) as never
+    );
 
     const res = await DELETE();
     expect(res.status).toBe(200);

--- a/app/api/households/route.ts
+++ b/app/api/households/route.ts
@@ -124,8 +124,9 @@ export async function DELETE() {
     if (!membership) return NextResponse.json({ error: '世帯に所属していません' }, { status: 404 });
     if (membership.role !== 'owner') return NextResponse.json({ error: 'オーナーのみ解散できます' }, { status: 403 });
 
-    // households を削除するとカスケードで members/invitations も削除される
-    const { error } = await supabase
+    // supabaseAdmin を使用: カスケード削除時に household_members / settlements 等の
+    // RLS DELETE ポリシーがブロックするため、サービスロールでバイパスする
+    const { error } = await supabaseAdmin
       .from('households')
       .delete()
       .eq('id', membership.household_id);

--- a/supabase/migrations/20260512000000_add_missing_delete_policies.sql
+++ b/supabase/migrations/20260512000000_add_missing_delete_policies.sql
@@ -1,0 +1,26 @@
+-- settlements / settlement_items / household_invitations の DELETE ポリシーが欠落していたため追加。
+-- households を削除する際のカスケード削除がRLSにブロックされる問題の根本対処。
+
+-- settlements: 世帯メンバーが削除可
+CREATE POLICY "settlements_delete" ON settlements
+  FOR DELETE TO authenticated
+  USING (
+    household_id = public.get_my_household_id()
+  );
+
+-- settlement_items: 対応する settlement に所属する世帯メンバーが削除可
+CREATE POLICY "settlement_items_delete" ON settlement_items
+  FOR DELETE TO authenticated
+  USING (
+    settlement_id IN (
+      SELECT id FROM settlements WHERE household_id = public.get_my_household_id()
+    )
+  );
+
+-- household_invitations: オーナーが削除可
+CREATE POLICY "household_invitations_delete" ON household_invitations
+  FOR DELETE TO authenticated
+  USING (
+    household_id = public.get_my_household_id()
+    AND public.get_my_household_role() = 'owner'
+  );


### PR DESCRIPTION
DELETE /api/households で supabase（ユーザークライアント）を使っていたため、
households 削除時のカスケード先（household_members 他メンバー行・
household_invitations・settlements）に DELETE ポリシーが適用されず失敗していた。
POSTと同様に supabaseAdmin（サービスロール）に切り替えてRLSをバイパスするよう変更。

あわせて settlements / settlement_items / household_invitations の
欠落していた RLS DELETE ポリシーをマイグレーションで追加。

https://claude.ai/code/session_01Fhms9hxwgwS6YBmsmLGfhf