### PR TITLE
feat: winstonによるログファイル出力を実装 (close #35)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,9 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 
+# logs
+/logs
+
 # env files (can opt-in for committing if needed)
 .env*
 

--- a/__tests__/lib/logger.test.ts
+++ b/__tests__/lib/logger.test.ts
@@ -23,13 +23,18 @@ vi.mock('fs', () => ({
 }));
 
 vi.mock('winston', () => {
-  const fmt = {
-    combine:   vi.fn((...fmts: unknown[]) => fmts),
-    timestamp: vi.fn(() => ({})),
-    colorize:  vi.fn(() => ({})),
-    printf:    vi.fn(() => ({})),
-    json:      vi.fn(() => ({})),
-  };
+  // winston.format は関数かつメソッド群を持つオブジェクト
+  // errorSerializer = winston.format(fn) のような呼び出しに対応するため callable にする
+  const fmt = Object.assign(
+    (_fn: unknown) => () => ({}),  // winston.format(fn)() → formatInstance
+    {
+      combine:   vi.fn((...fmts: unknown[]) => fmts),
+      timestamp: vi.fn(() => ({})),
+      colorize:  vi.fn(() => ({})),
+      printf:    vi.fn(() => ({})),
+      json:      vi.fn(() => ({})),
+    }
+  );
   const shared = {
     transports: { Console: MockConsoleTransport, File: MockFileTransport },
     format: fmt,
@@ -99,6 +104,25 @@ describe('logger (src/lib/logger.ts)', () => {
     it('logs/ ディレクトリが既存の場合は mkdirSync を呼ばない', async () => {
       mockExistsSync.mockReturnValue(true);
       await importLogger();
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── テスト環境 ───────────────────────────────────────────────────────────
+
+  describe('テスト環境（NODE_ENV=test）', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'test');
+    });
+
+    it('FileTransport は使用されない', async () => {
+      await importLogger();
+      expect(MockFileTransport).not.toHaveBeenCalled();
+    });
+
+    it('ファイルシステムにアクセスしない', async () => {
+      await importLogger();
+      expect(mockExistsSync).not.toHaveBeenCalled();
       expect(mockMkdirSync).not.toHaveBeenCalled();
     });
   });

--- a/__tests__/lib/logger.test.ts
+++ b/__tests__/lib/logger.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// vi.hoisted で vi.mock ファクトリから参照できる値を事前定義
+const { mockExistsSync, mockMkdirSync } = vi.hoisted(() => ({
+  mockExistsSync: vi.fn(() => true),
+  mockMkdirSync: vi.fn(),
+}));
+
+const { MockConsoleTransport, MockFileTransport, mockCreateLogger } = vi.hoisted(() => {
+  const MockConsoleTransport = vi.fn((opts: unknown) => ({ _type: 'Console', opts }));
+  const MockFileTransport   = vi.fn((opts: unknown) => ({ _type: 'File',    opts }));
+  const mockCreateLogger    = vi.fn((cfg: { level: string; transports: unknown[] }) => ({
+    level: cfg.level,
+    transports: cfg.transports,
+  }));
+  return { MockConsoleTransport, MockFileTransport, mockCreateLogger };
+});
+
+vi.mock('fs', () => ({
+  default: { existsSync: mockExistsSync, mkdirSync: mockMkdirSync },
+  existsSync: mockExistsSync,
+  mkdirSync:  mockMkdirSync,
+}));
+
+vi.mock('winston', () => {
+  const fmt = {
+    combine:   vi.fn((...fmts: unknown[]) => fmts),
+    timestamp: vi.fn(() => ({})),
+    colorize:  vi.fn(() => ({})),
+    printf:    vi.fn(() => ({})),
+    json:      vi.fn(() => ({})),
+  };
+  const shared = {
+    transports: { Console: MockConsoleTransport, File: MockFileTransport },
+    format: fmt,
+    createLogger: mockCreateLogger,
+  };
+  return { default: shared, ...shared };
+});
+
+// ─── テスト ───────────────────────────────────────────────────────────────────
+
+describe('logger (src/lib/logger.ts)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+    mockExistsSync.mockReturnValue(true);
+  });
+
+  const importLogger = () => import('@/lib/logger');
+
+  // ─── 開発環境 ─────────────────────────────────────────────────────────────
+
+  describe('開発環境（NODE_ENV=development, 非Vercel）', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'development');
+    });
+
+    it('ConsoleTransport と FileTransport の両方が設定される', async () => {
+      await importLogger();
+      expect(MockConsoleTransport).toHaveBeenCalledOnce();
+      expect(MockFileTransport).toHaveBeenCalledOnce();
+    });
+
+    it('createLogger に 2 つのトランスポートが渡される', async () => {
+      await importLogger();
+      const cfg = mockCreateLogger.mock.calls[0][0] as { transports: unknown[] };
+      expect(cfg.transports).toHaveLength(2);
+    });
+
+    it('FileTransport のファイル名が logs/app.log', async () => {
+      await importLogger();
+      const opts = MockFileTransport.mock.calls[0][0] as Record<string, unknown>;
+      expect(opts.filename).toMatch(/logs[/\\]app\.log$/);
+    });
+
+    it('FileTransport のローテーション閾値が 5 MB', async () => {
+      await importLogger();
+      const opts = MockFileTransport.mock.calls[0][0] as Record<string, unknown>;
+      expect(opts.maxsize).toBe(5 * 1024 * 1024);
+    });
+
+    it('FileTransport の保持ファイル数が 5', async () => {
+      await importLogger();
+      const opts = MockFileTransport.mock.calls[0][0] as Record<string, unknown>;
+      expect(opts.maxFiles).toBe(5);
+    });
+
+    it('logs/ ディレクトリが存在しない場合は mkdirSync で作成する', async () => {
+      mockExistsSync.mockReturnValue(false);
+      await importLogger();
+      expect(mockMkdirSync).toHaveBeenCalledWith(
+        expect.stringContaining('logs'),
+        { recursive: true }
+      );
+    });
+
+    it('logs/ ディレクトリが既存の場合は mkdirSync を呼ばない', async () => {
+      mockExistsSync.mockReturnValue(true);
+      await importLogger();
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Vercel 環境 ──────────────────────────────────────────────────────────
+
+  describe('Vercel 環境（VERCEL=1）', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'development');
+      vi.stubEnv('VERCEL', '1');
+    });
+
+    it('FileTransport は使用されない', async () => {
+      await importLogger();
+      expect(MockFileTransport).not.toHaveBeenCalled();
+    });
+
+    it('createLogger に渡されるトランスポートは 1 つのみ', async () => {
+      await importLogger();
+      const cfg = mockCreateLogger.mock.calls[0][0] as { transports: unknown[] };
+      expect(cfg.transports).toHaveLength(1);
+    });
+
+    it('ファイルシステムにアクセスしない', async () => {
+      await importLogger();
+      expect(mockExistsSync).not.toHaveBeenCalled();
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── 本番環境 ─────────────────────────────────────────────────────────────
+
+  describe('本番環境（NODE_ENV=production）', () => {
+    beforeEach(() => {
+      vi.stubEnv('NODE_ENV', 'production');
+    });
+
+    it('FileTransport は使用されない', async () => {
+      await importLogger();
+      expect(MockFileTransport).not.toHaveBeenCalled();
+    });
+
+    it('createLogger に渡されるトランスポートは 1 つのみ', async () => {
+      await importLogger();
+      const cfg = mockCreateLogger.mock.calls[0][0] as { transports: unknown[] };
+      expect(cfg.transports).toHaveLength(1);
+    });
+
+    it('ファイルシステムにアクセスしない', async () => {
+      await importLogger();
+      expect(mockExistsSync).not.toHaveBeenCalled();
+      expect(mockMkdirSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── ログレベル ───────────────────────────────────────────────────────────
+
+  describe('ログレベル設定', () => {
+    it('createLogger に level: info が設定される', async () => {
+      await importLogger();
+      const cfg = mockCreateLogger.mock.calls[0][0] as { level: string };
+      expect(cfg.level).toBe('info');
+    });
+  });
+});

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -43,7 +43,7 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ categories: result }, { status: 200 });
   } catch (e) {
-    logger.error('GET categories error:', e);
+    logger.error('GET categories error', { error: e });
     return NextResponse.json({ error: 'カテゴリの取得に失敗しました' }, { status: 500 });
   }
 }
@@ -73,7 +73,7 @@ export async function POST(request: Request) {
     if (error) throw error;
     return NextResponse.json({ category: data }, { status: 201 });
   } catch (e) {
-    logger.error('POST categories error:', e);
+    logger.error('POST categories error', { error: e });
     return NextResponse.json({ error: 'カテゴリの作成に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/categories/route.ts
+++ b/app/api/categories/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { requireAuth } from '@/lib/apiHelpers';
 import { CategoryCreateSchema, zodErrorToMessages } from '@/lib/validation';
+import { logger } from '@/lib/logger';
 
 // GET ?type=income|expense: カテゴリ一覧（マスタ + ユーザー独自）をサブカテゴリ付きで返す
 export async function GET(req: NextRequest) {
@@ -42,7 +43,7 @@ export async function GET(req: NextRequest) {
 
     return NextResponse.json({ categories: result }, { status: 200 });
   } catch (e) {
-    console.error('GET categories error:', e);
+    logger.error('GET categories error:', e);
     return NextResponse.json({ error: 'カテゴリの取得に失敗しました' }, { status: 500 });
   }
 }
@@ -72,7 +73,7 @@ export async function POST(request: Request) {
     if (error) throw error;
     return NextResponse.json({ category: data }, { status: 201 });
   } catch (e) {
-    console.error('POST categories error:', e);
+    logger.error('POST categories error:', e);
     return NextResponse.json({ error: 'カテゴリの作成に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/expense/route.ts
+++ b/app/api/expense/route.ts
@@ -4,6 +4,7 @@ import { requireAuth, parseListParams } from '@/lib/apiHelpers';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { ExpenseCreateSchema, ExpenseUpdateSchema } from '@/lib/validation/expense';
 import { zodErrorToMessages } from '@/lib/validation/common';
+import { logger } from '@/lib/logger';
 
 export async function GET(req: NextRequest) {
   const auth = await requireAuth();
@@ -29,7 +30,7 @@ export async function GET(req: NextRequest) {
     if (error) throw error;
     return NextResponse.json({ data, count, limit: params.limit, offset: params.offset }, { status: 200 });
   } catch (e) {
-    console.error('GET expense error:', e);
+    logger.error('GET expense error:', e);
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -82,7 +83,7 @@ export async function POST(request: Request) {
     if (error) throw error;
     return NextResponse.json({ message: '作成OK', data }, { status: 200 });
   } catch (e) {
-    console.error('POST expense error:', e);
+    logger.error('POST expense error:', e);
     return NextResponse.json({ error: '作成に失敗しました' }, { status: 500 });
   }
 }
@@ -107,7 +108,7 @@ export async function PATCH(request: Request) {
     if (error) throw error;
     return NextResponse.json({ message: '更新OK', data }, { status: 200 });
   } catch (e) {
-    console.error('PATCH expense error:', e);
+    logger.error('PATCH expense error:', e);
     return NextResponse.json({ error: '更新に失敗しました' }, { status: 500 });
   }
 }
@@ -126,7 +127,7 @@ export async function DELETE(request: NextRequest) {
     if (error) throw error;
     return NextResponse.json({ message: '削除OK' }, { status: 200 });
   } catch (e) {
-    console.error('DELETE expense error:', e);
+    logger.error('DELETE expense error:', e);
     return NextResponse.json({ error: '削除に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/expense/route.ts
+++ b/app/api/expense/route.ts
@@ -30,7 +30,7 @@ export async function GET(req: NextRequest) {
     if (error) throw error;
     return NextResponse.json({ data, count, limit: params.limit, offset: params.offset }, { status: 200 });
   } catch (e) {
-    logger.error('GET expense error:', e);
+    logger.error('GET expense error', { error: e });
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -83,7 +83,7 @@ export async function POST(request: Request) {
     if (error) throw error;
     return NextResponse.json({ message: '作成OK', data }, { status: 200 });
   } catch (e) {
-    logger.error('POST expense error:', e);
+    logger.error('POST expense error', { error: e });
     return NextResponse.json({ error: '作成に失敗しました' }, { status: 500 });
   }
 }
@@ -108,7 +108,7 @@ export async function PATCH(request: Request) {
     if (error) throw error;
     return NextResponse.json({ message: '更新OK', data }, { status: 200 });
   } catch (e) {
-    logger.error('PATCH expense error:', e);
+    logger.error('PATCH expense error', { error: e });
     return NextResponse.json({ error: '更新に失敗しました' }, { status: 500 });
   }
 }
@@ -127,7 +127,7 @@ export async function DELETE(request: NextRequest) {
     if (error) throw error;
     return NextResponse.json({ message: '削除OK' }, { status: 200 });
   } catch (e) {
-    logger.error('DELETE expense error:', e);
+    logger.error('DELETE expense error', { error: e });
     return NextResponse.json({ error: '削除に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/households/invite/route.ts
+++ b/app/api/households/invite/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
 import { HouseholdInviteSchema, zodErrorToMessages } from '@/lib/validation';
+import { logger } from '@/lib/logger';
 
 // GET ?token=xxx: 招待情報を取得（参加前のプレビュー用）
 export async function GET(req: NextRequest) {
@@ -34,7 +35,7 @@ export async function GET(req: NextRequest) {
       },
     }, { status: 200 });
   } catch (e) {
-    console.error('GET invite error:', e);
+    logger.error('GET invite error:', e);
     return NextResponse.json({ error: '招待情報の取得に失敗しました' }, { status: 500 });
   }
 }
@@ -81,7 +82,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ token: invitation.id }, { status: 201 });
   } catch (e) {
-    console.error('POST invite error:', e);
+    logger.error('POST invite error:', e);
     return NextResponse.json({ error: '招待の作成に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/households/invite/route.ts
+++ b/app/api/households/invite/route.ts
@@ -35,7 +35,7 @@ export async function GET(req: NextRequest) {
       },
     }, { status: 200 });
   } catch (e) {
-    logger.error('GET invite error:', e);
+    logger.error('GET invite error', { error: e });
     return NextResponse.json({ error: '招待情報の取得に失敗しました' }, { status: 500 });
   }
 }
@@ -82,7 +82,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ token: invitation.id }, { status: 201 });
   } catch (e) {
-    logger.error('POST invite error:', e);
+    logger.error('POST invite error', { error: e });
     return NextResponse.json({ error: '招待の作成に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/households/join/route.ts
+++ b/app/api/households/join/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { HouseholdJoinSchema, zodErrorToMessages } from '@/lib/validation';
+import { logger } from '@/lib/logger';
 
 // POST: 招待トークンで世帯に参加
 export async function POST(request: Request) {
@@ -60,7 +61,7 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (e) {
-    console.error('POST join error:', e);
+    logger.error('POST join error:', e);
     return NextResponse.json({ error: '参加に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/households/join/route.ts
+++ b/app/api/households/join/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: Request) {
       { status: 200 }
     );
   } catch (e) {
-    logger.error('POST join error:', e);
+    logger.error('POST join error', { error: e });
     return NextResponse.json({ error: '参加に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/households/leave/route.ts
+++ b/app/api/households/leave/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
+import { logger } from '@/lib/logger';
 
 // POST: 世帯から退出（メンバーのみ。オーナーは /api/households DELETE で解散）
 export async function POST() {
@@ -31,7 +32,7 @@ export async function POST() {
 
     return NextResponse.json({ message: '世帯から退出しました' }, { status: 200 });
   } catch (e) {
-    console.error('POST leave error:', e);
+    logger.error('POST leave error:', e);
     return NextResponse.json({ error: '退出に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/households/leave/route.ts
+++ b/app/api/households/leave/route.ts
@@ -32,7 +32,7 @@ export async function POST() {
 
     return NextResponse.json({ message: '世帯から退出しました' }, { status: 200 });
   } catch (e) {
-    logger.error('POST leave error:', e);
+    logger.error('POST leave error', { error: e });
     return NextResponse.json({ error: '退出に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/households/route.ts
+++ b/app/api/households/route.ts
@@ -54,7 +54,7 @@ export async function GET() {
       household: { ...household, role: membership.role, members: membersWithName },
     }, { status: 200 });
   } catch (e) {
-    logger.error('GET households error:', e);
+    logger.error('GET households error', { error: e });
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -104,7 +104,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ household }, { status: 201 });
   } catch (e) {
-    logger.error('POST households error:', e);
+    logger.error('POST households error', { error: e });
     return NextResponse.json({ error: '世帯の作成に失敗しました' }, { status: 500 });
   }
 }
@@ -136,7 +136,7 @@ export async function DELETE() {
 
     return NextResponse.json({ message: '世帯を解散しました' }, { status: 200 });
   } catch (e) {
-    logger.error('DELETE households error:', e);
+    logger.error('DELETE households error', { error: e });
     return NextResponse.json({ error: '世帯の解散に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/households/route.ts
+++ b/app/api/households/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { HouseholdCreateSchema, zodErrorToMessages } from '@/lib/validation';
+import { logger } from '@/lib/logger';
 
 // GET: 自分の世帯情報を取得
 export async function GET() {
@@ -53,7 +54,7 @@ export async function GET() {
       household: { ...household, role: membership.role, members: membersWithName },
     }, { status: 200 });
   } catch (e) {
-    console.error('GET households error:', e);
+    logger.error('GET households error:', e);
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -103,7 +104,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ household }, { status: 201 });
   } catch (e) {
-    console.error('POST households error:', e);
+    logger.error('POST households error:', e);
     return NextResponse.json({ error: '世帯の作成に失敗しました' }, { status: 500 });
   }
 }
@@ -135,7 +136,7 @@ export async function DELETE() {
 
     return NextResponse.json({ message: '世帯を解散しました' }, { status: 200 });
   } catch (e) {
-    console.error('DELETE households error:', e);
+    logger.error('DELETE households error:', e);
     return NextResponse.json({ error: '世帯の解散に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/income/route.ts
+++ b/app/api/income/route.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { requireAuth, parseListParams } from '@/lib/apiHelpers';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { IncomeCreateSchema, IncomeUpdateSchema, zodErrorToMessages } from '@/lib/validation';
+import { logger } from '@/lib/logger';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   const auth = await requireAuth();
@@ -28,7 +29,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     if (error) throw error;
     return NextResponse.json({ data, count, limit: params.limit, offset: params.offset }, { status: 200 });
   } catch (error) {
-    console.error('GET income error:', error);
+    logger.error('GET income error:', error);
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -78,7 +79,7 @@ export async function POST(request: Request) {
     if (error) throw error;
     return NextResponse.json({ message: '作成OK', data }, { status: 200 });
   } catch (error) {
-    console.error('POST income error:', error);
+    logger.error('POST income error:', error);
     return NextResponse.json({ error: '作成に失敗しました' }, { status: 500 });
   }
 }
@@ -100,7 +101,7 @@ export async function PATCH(request: Request) {
     if (error) throw error;
     return NextResponse.json({ message: '更新OK', data }, { status: 200 });
   } catch (error) {
-    console.error('PATCH income error:', error);
+    logger.error('PATCH income error:', error);
     return NextResponse.json({ error: '更新に失敗しました' }, { status: 500 });
   }
 }
@@ -119,7 +120,7 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     if (error) throw error;
     return NextResponse.json({ message: '削除OK' }, { status: 200 });
   } catch (error) {
-    console.error('DELETE income error:', error);
+    logger.error('DELETE income error:', error);
     return NextResponse.json({ error: '削除に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/income/route.ts
+++ b/app/api/income/route.ts
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     if (error) throw error;
     return NextResponse.json({ data, count, limit: params.limit, offset: params.offset }, { status: 200 });
   } catch (error) {
-    logger.error('GET income error:', error);
+    logger.error('GET income error', { error: error });
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -79,7 +79,7 @@ export async function POST(request: Request) {
     if (error) throw error;
     return NextResponse.json({ message: '作成OK', data }, { status: 200 });
   } catch (error) {
-    logger.error('POST income error:', error);
+    logger.error('POST income error', { error: error });
     return NextResponse.json({ error: '作成に失敗しました' }, { status: 500 });
   }
 }
@@ -101,7 +101,7 @@ export async function PATCH(request: Request) {
     if (error) throw error;
     return NextResponse.json({ message: '更新OK', data }, { status: 200 });
   } catch (error) {
-    logger.error('PATCH income error:', error);
+    logger.error('PATCH income error', { error: error });
     return NextResponse.json({ error: '更新に失敗しました' }, { status: 500 });
   }
 }
@@ -120,7 +120,7 @@ export async function DELETE(request: NextRequest): Promise<NextResponse> {
     if (error) throw error;
     return NextResponse.json({ message: '削除OK' }, { status: 200 });
   } catch (error) {
-    logger.error('DELETE income error:', error);
+    logger.error('DELETE income error', { error: error });
     return NextResponse.json({ error: '削除に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,6 +1,5 @@
 import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
 import { NextResponse } from 'next/server';
-import { logger } from '@/lib/logger';
 
 export async function GET() {
   const supabase = await createSupabaseServerClient();

--- a/app/api/logout/route.ts
+++ b/app/api/logout/route.ts
@@ -1,5 +1,6 @@
 import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
 import { NextResponse } from 'next/server';
+import { logger } from '@/lib/logger';
 
 export async function GET() {
   const supabase = await createSupabaseServerClient();

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -78,7 +78,7 @@ export async function PATCH(request: Request) {
     if (error) throw error;
     return NextResponse.json({ profile }, { status: 200 });
   } catch (e) {
-    logger.error('PATCH profile error:', e);
+    logger.error('PATCH profile error', { error: e });
     return NextResponse.json({ error: '更新に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabaseServerClient';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import { ProfileUpdateSchema, zodErrorToMessages } from '@/lib/validation';
+import { logger } from '@/lib/logger';
 
 // GET: 自分のプロフィールを取得
 export async function GET() {
@@ -77,7 +78,7 @@ export async function PATCH(request: Request) {
     if (error) throw error;
     return NextResponse.json({ profile }, { status: 200 });
   } catch (e) {
-    console.error('PATCH profile error:', e);
+    logger.error('PATCH profile error:', e);
     return NextResponse.json({ error: '更新に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/settlement/[id]/route.ts
+++ b/app/api/settlement/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/apiHelpers';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { logger } from '@/lib/logger';
 
 // GET /api/settlement/[id] — 精算詳細（対象明細の内容含む）
 export async function GET(
@@ -72,7 +73,7 @@ export async function GET(
 
     return NextResponse.json({ data: { ...settlement, split_ratios: enrichedRatios, items: enrichedItems } });
   } catch (e) {
-    console.error('GET settlement/[id] error:', e);
+    logger.error('GET settlement/[id] error:', e);
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -123,7 +124,7 @@ export async function PATCH(
 
     return NextResponse.json({ message: 'キャンセルOK' });
   } catch (e) {
-    console.error('PATCH settlement/[id] error:', e);
+    logger.error('PATCH settlement/[id] error:', e);
     return NextResponse.json({ error: 'キャンセルに失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/settlement/[id]/route.ts
+++ b/app/api/settlement/[id]/route.ts
@@ -73,7 +73,7 @@ export async function GET(
 
     return NextResponse.json({ data: { ...settlement, split_ratios: enrichedRatios, items: enrichedItems } });
   } catch (e) {
-    logger.error('GET settlement/[id] error:', e);
+    logger.error('GET settlement/[id] error', { error: e });
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -124,7 +124,7 @@ export async function PATCH(
 
     return NextResponse.json({ message: 'キャンセルOK' });
   } catch (e) {
-    logger.error('PATCH settlement/[id] error:', e);
+    logger.error('PATCH settlement/[id] error', { error: e });
     return NextResponse.json({ error: 'キャンセルに失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/settlement/route.ts
+++ b/app/api/settlement/route.ts
@@ -4,6 +4,7 @@ import { requireAuth } from '@/lib/apiHelpers';
 import { supabaseAdmin } from '@/lib/supabaseAdmin';
 import type { SplitRatio, Payment, SettlementItem } from '@/lib/settlementCalc';
 import { calcPayments } from '@/lib/settlementCalc';
+import { logger } from '@/lib/logger';
 
 // GET /api/settlement — 自世帯の精算履歴一覧
 export async function GET(req: NextRequest) {
@@ -30,7 +31,7 @@ export async function GET(req: NextRequest) {
     if (error) throw error;
     return NextResponse.json({ data, count, limit, offset });
   } catch (e) {
-    console.error('GET settlement error:', e);
+    logger.error('GET settlement error:', e);
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -120,7 +121,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ message: '精算OK', data: settlement }, { status: 200 });
   } catch (e) {
-    console.error('POST settlement error:', e);
+    logger.error('POST settlement error:', e);
     return NextResponse.json({ error: '精算に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/settlement/route.ts
+++ b/app/api/settlement/route.ts
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest) {
     if (error) throw error;
     return NextResponse.json({ data, count, limit, offset });
   } catch (e) {
-    logger.error('GET settlement error:', e);
+    logger.error('GET settlement error', { error: e });
     return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
   }
 }
@@ -121,7 +121,7 @@ export async function POST(request: Request) {
 
     return NextResponse.json({ message: '精算OK', data: settlement }, { status: 200 });
   } catch (e) {
-    logger.error('POST settlement error:', e);
+    logger.error('POST settlement error', { error: e });
     return NextResponse.json({ error: '精算に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/subcategories/route.ts
+++ b/app/api/subcategories/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { requireAuth } from '@/lib/apiHelpers';
 import { SubcategoryCreateSchema, zodErrorToMessages } from '@/lib/validation';
+import { logger } from '@/lib/logger';
 
 // POST: ユーザー独自サブカテゴリを作成
 export async function POST(request: Request) {
@@ -36,7 +37,7 @@ export async function POST(request: Request) {
     if (error) throw error;
     return NextResponse.json({ subcategory: data }, { status: 201 });
   } catch (e) {
-    console.error('POST subcategories error:', e);
+    logger.error('POST subcategories error:', e);
     return NextResponse.json({ error: 'サブカテゴリの作成に失敗しました' }, { status: 500 });
   }
 }

--- a/app/api/subcategories/route.ts
+++ b/app/api/subcategories/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: Request) {
     if (error) throw error;
     return NextResponse.json({ subcategory: data }, { status: 201 });
   } catch (e) {
-    logger.error('POST subcategories error:', e);
+    logger.error('POST subcategories error', { error: e });
     return NextResponse.json({ error: 'サブカテゴリの作成に失敗しました' }, { status: 500 });
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "recharts": "^3.8.1",
+        "winston": "^3.19.0",
         "zod": "^4.1.0"
       },
       "devDependencies": {
@@ -377,6 +378,26 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -2193,6 +2214,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2470,6 +2501,12 @@
       "dependencies": {
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -3193,6 +3230,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -3548,6 +3591,19 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3567,6 +3623,48 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -3965,6 +4063,12 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
       "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
@@ -4796,6 +4900,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "license": "MIT"
+    },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
@@ -4891,6 +5001,12 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "license": "MIT"
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -5353,7 +5469,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -5697,6 +5812,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -5936,6 +6063,12 @@
       "dependencies": {
         "json-buffer": "3.0.1"
       }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/language-subtag-registry": {
       "version": "0.3.23",
@@ -6288,6 +6421,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -6408,7 +6558,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -6742,6 +6891,15 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
       }
     },
     "node_modules/optionator": {
@@ -7251,6 +7409,20 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7510,6 +7682,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -7526,6 +7718,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/scheduler": {
@@ -7715,6 +7916,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -7728,6 +7938,15 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -8209,6 +8428,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -8358,6 +8583,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8592,7 +8826,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/victory-vendor": {
@@ -8956,6 +9189,42 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "recharts": "^3.8.1",
+    "winston": "^3.19.0",
     "zod": "^4.1.0"
   },
   "devDependencies": {

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -3,19 +3,35 @@ import path from 'path';
 import fs from 'fs';
 
 const isVercel = Boolean(process.env.VERCEL);
-const isDev = process.env.NODE_ENV !== 'production';
+const isDev = process.env.NODE_ENV === 'development';
+
+// { error: Error } を JSON シリアライズ可能な形式に変換する
+const errorSerializer = winston.format((info) => {
+  const err = info['error'];
+  if (err instanceof Error) {
+    info['error'] = { message: err.message, name: err.name, stack: err.stack };
+  }
+  return info;
+});
 
 const jsonFormat = winston.format.combine(
+  errorSerializer(),
   winston.format.timestamp(),
   winston.format.json()
 );
 
 const prettyFormat = winston.format.combine(
+  errorSerializer(),
   winston.format.colorize(),
   winston.format.timestamp({ format: 'HH:mm:ss' }),
-  winston.format.printf(({ timestamp, level, message, ...meta }) => {
+  winston.format.printf((info) => {
+    const { timestamp, level, message, error, ...meta } = info as {
+      timestamp: string; level: string; message: string;
+      error?: unknown; [key: string]: unknown;
+    };
+    const errStr  = error ? ` error=${JSON.stringify(error)}` : '';
     const metaStr = Object.keys(meta).length ? ' ' + JSON.stringify(meta) : '';
-    return `${timestamp} [${level}] ${message}${metaStr}`;
+    return `${timestamp} [${level}] ${message}${errStr}${metaStr}`;
   })
 );
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,48 @@
+import winston from 'winston';
+import path from 'path';
+import fs from 'fs';
+
+const isVercel = Boolean(process.env.VERCEL);
+const isDev = process.env.NODE_ENV !== 'production';
+
+const jsonFormat = winston.format.combine(
+  winston.format.timestamp(),
+  winston.format.json()
+);
+
+const prettyFormat = winston.format.combine(
+  winston.format.colorize(),
+  winston.format.timestamp({ format: 'HH:mm:ss' }),
+  winston.format.printf(({ timestamp, level, message, ...meta }) => {
+    const metaStr = Object.keys(meta).length ? ' ' + JSON.stringify(meta) : '';
+    return `${timestamp} [${level}] ${message}${metaStr}`;
+  })
+);
+
+const transports: winston.transport[] = [
+  new winston.transports.Console({
+    format: isDev ? prettyFormat : jsonFormat,
+  }),
+];
+
+// ファイル出力: ローカル開発時のみ（Vercel ではファイル書き込み不可）
+if (isDev && !isVercel) {
+  const logsDir = path.join(process.cwd(), 'logs');
+  if (!fs.existsSync(logsDir)) {
+    fs.mkdirSync(logsDir, { recursive: true });
+  }
+
+  transports.push(
+    new winston.transports.File({
+      filename: path.join(logsDir, 'app.log'),
+      maxsize: 5 * 1024 * 1024, // 5MB でローテーション
+      maxFiles: 5,
+      format: jsonFormat,
+    })
+  );
+}
+
+export const logger = winston.createLogger({
+  level: 'info',
+  transports,
+});


### PR DESCRIPTION
- src/lib/logger.ts を新設（info/warn/error レベル対応）
- 開発環境ではコンソール＋ logs/app.log に出力（5MB でローテーション）
- 本番（Vercel）ではコンソール（stdout）のみ
- 全 API ルートの console.error を logger.error に置き換え
- logs/ を .gitignore に追加

https://claude.ai/code/session_01WtgV4uXa7hyR46vStdmwFV