### PR TITLE
feat: 月次収支推移グラフを追加 (close #14)

### DIFF
--- a/__tests__/api/report.monthly.test.ts
+++ b/__tests__/api/report.monthly.test.ts
@@ -101,6 +101,15 @@ describe('GET /api/report/monthly', () => {
     expect(body.data).toHaveLength(1);
   });
 
+  it('months に非数値が渡された場合はデフォルト 12 を使う', async () => {
+    makeIncomeExpenseMocks([], []);
+    const req = new NextRequest('http://localhost/api/report/monthly?months=abc');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(12);
+  });
+
   it('最新月が現在月（2026-05）である', async () => {
     makeIncomeExpenseMocks([], []);
     const req = new NextRequest('http://localhost/api/report/monthly?months=3');

--- a/__tests__/api/report.monthly.test.ts
+++ b/__tests__/api/report.monthly.test.ts
@@ -1,0 +1,202 @@
+import { NextRequest } from 'next/server';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeQueryMock } from '../helpers/queryMock';
+
+const mockFrom = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock('@/lib/supabaseServerClient', () => ({
+  createSupabaseServerClient: vi.fn(() =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+      from: mockFrom,
+    })
+  ),
+}));
+
+vi.mock('@/lib/supabaseAdmin', () => ({
+  supabaseAdmin: { from: vi.fn() },
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), delete: vi.fn() })),
+}));
+
+vi.mock('@/lib/logger', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { GET } from '../../app/api/report/monthly/route';
+
+const TEST_USER = { id: 'user-123', email: 'test@example.com' };
+
+// テストで "今" を固定: 2026-05-16（月曜）
+const FIXED_NOW = new Date('2026-05-16T00:00:00Z');
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.setSystemTime(FIXED_NOW);
+  mockGetUser.mockResolvedValue({ data: { user: TEST_USER } });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ─── 認証チェック ─────────────────────────────────────────────────────────────
+
+describe('認証チェック', () => {
+  it('未認証は 401 を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const req = new NextRequest('http://localhost/api/report/monthly');
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── 正常系 ───────────────────────────────────────────────────────────────────
+
+describe('GET /api/report/monthly', () => {
+  function makeIncomeExpenseMocks(
+    incomeData: object[],
+    expenseData: object[]
+  ) {
+    // from('income') → income mock, from('expense') → expense mock
+    mockFrom
+      .mockImplementationOnce(() => makeQueryMock({ data: incomeData, error: null }))
+      .mockImplementationOnce(() => makeQueryMock({ data: expenseData, error: null }));
+  }
+
+  it('デフォルトで 12 ヶ月分のデータを返す', async () => {
+    makeIncomeExpenseMocks([], []);
+    const req = new NextRequest('http://localhost/api/report/monthly');
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data).toHaveLength(12);
+  });
+
+  it('months パラメータで件数を指定できる', async () => {
+    makeIncomeExpenseMocks([], []);
+    const req = new NextRequest('http://localhost/api/report/monthly?months=6');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.data).toHaveLength(6);
+  });
+
+  it('months の上限は 24', async () => {
+    makeIncomeExpenseMocks([], []);
+    const req = new NextRequest('http://localhost/api/report/monthly?months=999');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.data).toHaveLength(24);
+  });
+
+  it('months の下限は 1', async () => {
+    makeIncomeExpenseMocks([], []);
+    const req = new NextRequest('http://localhost/api/report/monthly?months=0');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.data).toHaveLength(1);
+  });
+
+  it('最新月が現在月（2026-05）である', async () => {
+    makeIncomeExpenseMocks([], []);
+    const req = new NextRequest('http://localhost/api/report/monthly?months=3');
+    const res = await GET(req);
+    const body = await res.json();
+    const months = body.data.map((d: { month: string }) => d.month);
+    expect(months).toEqual(['2026-03', '2026-04', '2026-05']);
+  });
+
+  it('収入・支出がない月は income=0, expense=0 で返る', async () => {
+    makeIncomeExpenseMocks([], []);
+    const req = new NextRequest('http://localhost/api/report/monthly?months=1');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.data[0]).toMatchObject({ income: 0, expense: 0, balance: 0 });
+  });
+
+  it('収入を正しく集計する', async () => {
+    makeIncomeExpenseMocks(
+      [
+        { amount: 200000, entry_date: '2026-05-01' },
+        { amount: 50000,  entry_date: '2026-05-15' },
+      ],
+      []
+    );
+    const req = new NextRequest('http://localhost/api/report/monthly?months=1');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.data[0]).toMatchObject({ month: '2026-05', income: 250000, expense: 0, balance: 250000 });
+  });
+
+  it('支出を正しく集計する', async () => {
+    makeIncomeExpenseMocks(
+      [],
+      [
+        { amount: 30000, entry_date: '2026-05-10' },
+        { amount: 15000, entry_date: '2026-05-20' },
+      ]
+    );
+    const req = new NextRequest('http://localhost/api/report/monthly?months=1');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.data[0]).toMatchObject({ month: '2026-05', income: 0, expense: 45000, balance: -45000 });
+  });
+
+  it('balance = income - expense', async () => {
+    makeIncomeExpenseMocks(
+      [{ amount: 300000, entry_date: '2026-05-01' }],
+      [{ amount: 120000, entry_date: '2026-05-05' }]
+    );
+    const req = new NextRequest('http://localhost/api/report/monthly?months=1');
+    const res = await GET(req);
+    const body = await res.json();
+    expect(body.data[0].balance).toBe(180000);
+  });
+
+  it('複数月にまたがるデータをそれぞれの月に振り分ける', async () => {
+    makeIncomeExpenseMocks(
+      [
+        { amount: 100000, entry_date: '2026-04-01' },
+        { amount: 200000, entry_date: '2026-05-01' },
+      ],
+      []
+    );
+    const req = new NextRequest('http://localhost/api/report/monthly?months=2');
+    const res = await GET(req);
+    const body = await res.json();
+    const apr = body.data.find((d: { month: string }) => d.month === '2026-04');
+    const may = body.data.find((d: { month: string }) => d.month === '2026-05');
+    expect(apr.income).toBe(100000);
+    expect(may.income).toBe(200000);
+  });
+
+  it('対象期間外のデータは無視される', async () => {
+    // months=1 なので 2026-04 以前は対象外
+    makeIncomeExpenseMocks(
+      [
+        { amount: 999999, entry_date: '2026-04-30' }, // 対象外
+        { amount: 100000, entry_date: '2026-05-01' }, // 対象内
+      ],
+      []
+    );
+    const req = new NextRequest('http://localhost/api/report/monthly?months=1');
+    const res = await GET(req);
+    const body = await res.json();
+    // 対象外の月のデータは monthMap に存在しないためスキップされる
+    expect(body.data[0].income).toBe(100000);
+  });
+
+  it('DB エラー時は 500 を返す', async () => {
+    mockFrom
+      .mockImplementationOnce(() => makeQueryMock({ data: null, error: new Error('DB error') }))
+      .mockImplementationOnce(() => makeQueryMock({ data: [], error: null }));
+    const req = new NextRequest('http://localhost/api/report/monthly');
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: 'データ取得に失敗しました' });
+  });
+});

--- a/app/api/report/monthly/route.ts
+++ b/app/api/report/monthly/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { requireAuth } from '@/lib/apiHelpers';
+import { logger } from '@/lib/logger';
+
+export async function GET(req: NextRequest) {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { supabase } = auth;
+
+  const months = Math.min(24, Math.max(1, Number(new URL(req.url).searchParams.get('months') ?? 12)));
+
+  const now = new Date();
+  const from = new Date(now.getFullYear(), now.getMonth() - months + 1, 1);
+  const fromDate = from.toISOString().slice(0, 10);
+
+  try {
+    const [incomeRes, expenseRes] = await Promise.all([
+      supabase.from('income').select('amount, entry_date').gte('entry_date', fromDate),
+      supabase.from('expense').select('amount, entry_date').gte('entry_date', fromDate),
+    ]);
+
+    if (incomeRes.error) throw incomeRes.error;
+    if (expenseRes.error) throw expenseRes.error;
+
+    // 過去 N ヶ月分のスロットをゼロ埋めで初期化
+    const monthMap: Record<string, { income: number; expense: number }> = {};
+    for (let i = 0; i < months; i++) {
+      const d = new Date(now.getFullYear(), now.getMonth() - months + 1 + i, 1);
+      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+      monthMap[key] = { income: 0, expense: 0 };
+    }
+
+    for (const r of incomeRes.data ?? []) {
+      const key = r.entry_date.slice(0, 7);
+      if (monthMap[key]) monthMap[key].income += Number(r.amount);
+    }
+    for (const r of expenseRes.data ?? []) {
+      const key = r.entry_date.slice(0, 7);
+      if (monthMap[key]) monthMap[key].expense += Number(r.amount);
+    }
+
+    const data = Object.entries(monthMap).map(([month, { income, expense }]) => ({
+      month,
+      income,
+      expense,
+      balance: income - expense,
+    }));
+
+    return NextResponse.json({ data });
+  } catch (e) {
+    logger.error('GET report/monthly error', { error: e });
+    return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
+  }
+}

--- a/app/api/report/monthly/route.ts
+++ b/app/api/report/monthly/route.ts
@@ -8,11 +8,13 @@ export async function GET(req: NextRequest) {
   if (auth.errorResponse) return auth.errorResponse;
   const { supabase } = auth;
 
-  const months = Math.min(24, Math.max(1, Number(new URL(req.url).searchParams.get('months') ?? 12)));
+  const raw = Number(new URL(req.url).searchParams.get('months') ?? 12);
+  const months = Math.min(24, Math.max(1, isNaN(raw) ? 12 : raw));
 
   const now = new Date();
   const from = new Date(now.getFullYear(), now.getMonth() - months + 1, 1);
-  const fromDate = from.toISOString().slice(0, 10);
+  // toISOString() は UTC 変換するためタイムゾーン依存で日付がずれる。文字列で組み立てる
+  const fromDate = `${from.getFullYear()}-${String(from.getMonth() + 1).padStart(2, '0')}-01`;
 
   try {
     const [incomeRes, expenseRes] = await Promise.all([

--- a/app/page.js
+++ b/app/page.js
@@ -4,6 +4,7 @@ import { Suspense } from "react";
 import { createSupabaseServerClient } from "@/lib/supabaseServerClient";
 import MonthNav from "@/components/MonthNav";
 import CategoryPieChart from "@/components/CategoryPieChart";
+import MonthlyBarChart from "@/components/MonthlyBarChart";
 import { parseMonth, monthToRange } from "@/lib/monthUtils";
 
 function formatAmount(amount) {
@@ -182,6 +183,14 @@ export default async function Home({ searchParams }) {
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
         <CategoryPieChart data={expenseByCategory} title="支出カテゴリ別" />
         <CategoryPieChart data={incomeByCategory} title="収入カテゴリ別" />
+      </div>
+
+      {/* 収支推移グラフ */}
+      <div className="mt-6">
+        <h2 className="text-sm font-semibold text-gray-400 mb-3">収支推移（過去12ヶ月）</h2>
+        <div className="bg-gray-800 rounded-xl p-4">
+          <MonthlyBarChart months={12} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/MonthlyBarChart.tsx
+++ b/src/components/MonthlyBarChart.tsx
@@ -30,12 +30,18 @@ const LEGEND_LABELS: Record<string, string> = {
 export default function MonthlyBarChart({ months = 12 }: { months?: number }) {
   const [data, setData] = useState<MonthlyData[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
   useEffect(() => {
-    fetch(`/api/report/monthly?months=${months}`, { cache: 'no-store' })
-      .then(r => r.json())
+    setLoading(true);
+    setError(false);
+    fetch(`/api/report/monthly?months=${months}`)
+      .then(r => {
+        if (!r.ok) throw new Error(`${r.status}`);
+        return r.json();
+      })
       .then(j => setData(j.data ?? []))
-      .catch(() => setData([]))
+      .catch(() => setError(true))
       .finally(() => setLoading(false));
   }, [months]);
 
@@ -43,6 +49,14 @@ export default function MonthlyBarChart({ months = 12 }: { months?: number }) {
     return (
       <div className="h-52 flex items-center justify-center text-gray-500 text-sm">
         読み込み中...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="h-52 flex items-center justify-center text-red-400 text-sm">
+        データの取得に失敗しました
       </div>
     );
   }

--- a/src/components/MonthlyBarChart.tsx
+++ b/src/components/MonthlyBarChart.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer,
+} from 'recharts';
+
+type MonthlyData = {
+  month: string;
+  income: number;
+  expense: number;
+  balance: number;
+};
+
+function formatYen(n: number) {
+  if (Math.abs(n) >= 10000) return `¥${Math.round(n / 10000)}万`;
+  return `¥${new Intl.NumberFormat('ja-JP').format(n)}`;
+}
+
+function shortMonth(yyyymm: string) {
+  const [y, m] = yyyymm.split('-');
+  return `${y.slice(2)}/${Number(m)}`;
+}
+
+const LEGEND_LABELS: Record<string, string> = {
+  income: '収入',
+  expense: '支出',
+};
+
+export default function MonthlyBarChart({ months = 12 }: { months?: number }) {
+  const [data, setData] = useState<MonthlyData[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`/api/report/monthly?months=${months}`, { cache: 'no-store' })
+      .then(r => r.json())
+      .then(j => setData(j.data ?? []))
+      .catch(() => setData([]))
+      .finally(() => setLoading(false));
+  }, [months]);
+
+  if (loading) {
+    return (
+      <div className="h-52 flex items-center justify-center text-gray-500 text-sm">
+        読み込み中...
+      </div>
+    );
+  }
+
+  if (data.every(d => d.income === 0 && d.expense === 0)) {
+    return (
+      <div className="h-52 flex items-center justify-center text-gray-500 text-sm">
+        データなし
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={208}>
+      <BarChart data={data} margin={{ top: 4, right: 8, left: 0, bottom: 0 }}>
+        <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+        <XAxis
+          dataKey="month"
+          tickFormatter={shortMonth}
+          tick={{ fill: '#9ca3af', fontSize: 11 }}
+        />
+        <YAxis
+          tickFormatter={formatYen}
+          tick={{ fill: '#9ca3af', fontSize: 11 }}
+          width={52}
+        />
+        <Tooltip
+          formatter={(value: number, name: string) => [
+            `¥${new Intl.NumberFormat('ja-JP').format(value)}`,
+            LEGEND_LABELS[name] ?? name,
+          ]}
+          labelFormatter={(label: string) => label}
+          contentStyle={{ backgroundColor: '#1f2937', border: 'none', borderRadius: '8px' }}
+          labelStyle={{ color: '#e5e7eb' }}
+          itemStyle={{ color: '#e5e7eb' }}
+        />
+        <Legend formatter={(value: string) => LEGEND_LABELS[value] ?? value} />
+        <Bar dataKey="income"  name="income"  fill="#4ade80" radius={[3, 3, 0, 0]} />
+        <Bar dataKey="expense" name="expense" fill="#f87171" radius={[3, 3, 0, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
## Summary

- `GET /api/report/monthly`: 過去 N ヶ月の収入・支出を月別集計して返す（データなし月はゼロ埋め）
- `MonthlyBarChart`: Recharts BarChart で収入（緑）・支出（赤）を並列バー表示
- ホームページ下部に「収支推移（過去12ヶ月）」セクションを追加

## レビュー対応済み

- `fromDate` を `toISOString()` → 文字列直接組み立てに変更（JST 環境でのタイムゾーンずれ修正）
- 非数値 `months` パラメータ時に NaN → デフォルト 12 にフォールバック
- フェッチ失敗を「データなし」と区別してエラーメッセージを表示

## Test plan

- [ ] `GET /api/report/monthly` ユニットテスト 14件（認証・件数上下限・集計・NaN入力・DBエラー）
- [ ] 全テスト 126件パス確認

https://claude.ai/code/session_01WtgV4uXa7hyR46vStdmwFV

---
_Generated by [Claude Code](https://claude.ai/code/session_01WtgV4uXa7hyR46vStdmwFV)_