### PR TITLE
feat: 繰り返しエントリ機能を追加

### DIFF
--- a/__tests__/api/recurring.apply.test.ts
+++ b/__tests__/api/recurring.apply.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { makeQueryMock } from '../helpers/queryMock';
+
+const { mockAdminFrom } = vi.hoisted(() => ({ mockAdminFrom: vi.fn() }));
+
+const mockFrom = vi.fn();
+const mockGetUser = vi.fn();
+
+vi.mock('@/lib/supabaseServerClient', () => ({
+  createSupabaseServerClient: vi.fn(() =>
+    Promise.resolve({
+      auth: { getUser: mockGetUser },
+      from: mockFrom,
+    })
+  ),
+}));
+
+vi.mock('@/lib/supabaseAdmin', () => ({
+  supabaseAdmin: { from: mockAdminFrom },
+}));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(() => ({ get: vi.fn(), set: vi.fn(), delete: vi.fn() })),
+}));
+
+import { POST } from '../../app/api/recurring/apply/route';
+
+const TEST_USER = { id: 'user-123', email: 'test@example.com' };
+const MISC_CAT_ID = 'cat-misc-uuid';
+const MISC_SUB_ID = 'sub-misc-uuid';
+
+// 今日を固定
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date('2026-05-21T00:00:00.000Z'));
+  vi.resetAllMocks(); // mockImplementationOnce の残留を防ぐ
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** 未分類ID取得（supabaseAdmin）のモックを設定 */
+function setupAdminMiscMocks() {
+  const catMock = makeQueryMock({ data: { id: MISC_CAT_ID }, error: null });
+  const subMock = makeQueryMock({ data: { id: MISC_SUB_ID }, error: null });
+  // income用 categories → subcategories、expense用 categories → subcategories
+  mockAdminFrom
+    .mockImplementationOnce(() => catMock)
+    .mockImplementationOnce(() => subMock)
+    .mockImplementationOnce(() => catMock)
+    .mockImplementationOnce(() => subMock);
+}
+
+const BASE_ENTRY = {
+  id: 1,
+  user_id: TEST_USER.id,
+  type: 'expense',
+  source: '家賃',
+  amount: 80000,
+  subcategory_id: null,
+  owner: 'self',
+  needs_settlement: false,
+  frequency: 'monthly',
+  day_of_month: 1,
+  month_of_year: null,
+  next_apply_date: '2026-05-01', // 今日より前なのでdue
+  is_active: true,
+  household_id: null,
+};
+
+// ─── 認証チェック ─────────────────────────────────────────────────────────────
+
+describe('認証チェック', () => {
+  it('未認証は401を返す', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST();
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── POST /api/recurring/apply ────────────────────────────────────────────────
+
+describe('POST /api/recurring/apply', () => {
+  beforeEach(() => {
+    mockGetUser.mockResolvedValue({ data: { user: TEST_USER } });
+  });
+
+  it('期限切れエントリがない場合は applied: 0 を返す', async () => {
+    const duesQ = makeQueryMock({ data: [], error: null });
+    mockFrom.mockReturnValue(duesQ);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ applied: 0 });
+  });
+
+  it('期限切れエントリを1件適用し applied: 1 を返す', async () => {
+    const duesQ = makeQueryMock({ data: [BASE_ENTRY], error: null });
+    const membershipQ = makeQueryMock({ data: null, error: null });
+    const claimQ = makeQueryMock({ data: [{ id: 1 }], error: null });
+    const insertQ = makeQueryMock({ data: [{ id: 100 }], error: null });
+
+    mockFrom
+      .mockImplementationOnce(() => duesQ)
+      .mockImplementationOnce(() => membershipQ)
+      .mockImplementationOnce(() => claimQ)
+      .mockImplementationOnce(() => insertQ);
+
+    setupAdminMiscMocks();
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ applied: 1 });
+  });
+
+  it('クレーム成功時に income/expense テーブルへ insert する', async () => {
+    const duesQ = makeQueryMock({ data: [BASE_ENTRY], error: null });
+    const membershipQ = makeQueryMock({ data: null, error: null });
+    const claimQ = makeQueryMock({ data: [{ id: 1 }], error: null });
+    const insertQ = makeQueryMock({ data: [{ id: 100 }], error: null });
+
+    mockFrom
+      .mockImplementationOnce(() => duesQ)
+      .mockImplementationOnce(() => membershipQ)
+      .mockImplementationOnce(() => claimQ)
+      .mockImplementationOnce(() => insertQ);
+
+    setupAdminMiscMocks();
+
+    await POST();
+
+    expect(insertQ.insert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({
+          source: '家賃',
+          amount: 80000,
+          entry_date: '2026-05-01',
+          user_id: TEST_USER.id,
+        }),
+      ])
+    );
+  });
+
+  it('クレームに失敗（0件返却）した場合は insert しない（二重適用防止）', async () => {
+    const duesQ = makeQueryMock({ data: [BASE_ENTRY], error: null });
+    const membershipQ = makeQueryMock({ data: null, error: null });
+    // 別リクエストがすでに next_apply_date を更新済み → 0件返却
+    const claimQ = makeQueryMock({ data: [], error: null });
+    const insertQ = makeQueryMock({ data: [{ id: 100 }], error: null });
+
+    mockFrom
+      .mockImplementationOnce(() => duesQ)
+      .mockImplementationOnce(() => membershipQ)
+      .mockImplementationOnce(() => claimQ)
+      .mockImplementationOnce(() => insertQ);
+
+    setupAdminMiscMocks();
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ applied: 0 });
+    expect(insertQ.insert).not.toHaveBeenCalled();
+  });
+
+  it('insert 失敗は applied にカウントしない', async () => {
+    const duesQ = makeQueryMock({ data: [BASE_ENTRY], error: null });
+    const membershipQ = makeQueryMock({ data: null, error: null });
+    const claimQ = makeQueryMock({ data: [{ id: 1 }], error: null });
+    const insertQ = makeQueryMock({ data: null, error: new Error('DB error') });
+
+    mockFrom
+      .mockImplementationOnce(() => duesQ)
+      .mockImplementationOnce(() => membershipQ)
+      .mockImplementationOnce(() => claimQ)
+      .mockImplementationOnce(() => insertQ);
+
+    setupAdminMiscMocks();
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ applied: 0 });
+  });
+
+  it('next_apply_date の更新に使用する日付が正しい（毎月1日 → 6月1日）', async () => {
+    const duesQ = makeQueryMock({ data: [BASE_ENTRY], error: null });
+    const membershipQ = makeQueryMock({ data: null, error: null });
+    const claimQ = makeQueryMock({ data: [{ id: 1 }], error: null });
+    const insertQ = makeQueryMock({ data: [{ id: 100 }], error: null });
+
+    mockFrom
+      .mockImplementationOnce(() => duesQ)
+      .mockImplementationOnce(() => membershipQ)
+      .mockImplementationOnce(() => claimQ)
+      .mockImplementationOnce(() => insertQ);
+
+    setupAdminMiscMocks();
+
+    await POST();
+
+    expect(claimQ.update).toHaveBeenCalledWith(
+      expect.objectContaining({ next_apply_date: '2026-06-01' })
+    );
+  });
+
+  it('世帯所属中は household_id が insert に含まれる', async () => {
+    const HOUSEHOLD_ID = 'hh-uuid-456';
+    const duesQ = makeQueryMock({ data: [BASE_ENTRY], error: null });
+    const membershipQ = makeQueryMock({ data: { household_id: HOUSEHOLD_ID }, error: null });
+    const claimQ = makeQueryMock({ data: [{ id: 1 }], error: null });
+    const insertQ = makeQueryMock({ data: [{ id: 100 }], error: null });
+
+    mockFrom
+      .mockImplementationOnce(() => duesQ)
+      .mockImplementationOnce(() => membershipQ)
+      .mockImplementationOnce(() => claimQ)
+      .mockImplementationOnce(() => insertQ);
+
+    setupAdminMiscMocks();
+
+    await POST();
+
+    expect(insertQ.insert).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ household_id: HOUSEHOLD_ID }),
+      ])
+    );
+  });
+});

--- a/__tests__/helpers/queryMock.ts
+++ b/__tests__/helpers/queryMock.ts
@@ -23,6 +23,7 @@ export function makeQueryMock(result: object) {
   q.range = vi.fn(() => Promise.resolve(result));
   q.eq = vi.fn(chain);
   q.neq = vi.fn(chain);
+  q.is = vi.fn(chain);
   q.in = vi.fn(chain);
   q.maybeSingle = vi.fn(() => Promise.resolve(result));
   q.single = vi.fn(() => Promise.resolve(result));

--- a/__tests__/lib/recurringUtils.test.ts
+++ b/__tests__/lib/recurringUtils.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { calcNextApplyDate, calcInitialNextApplyDate } from '../../src/lib/recurringUtils';
+
+// 今日 = 2026-05-21 に固定
+const TODAY = new Date('2026-05-21T00:00:00.000Z');
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(TODAY);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ─── calcNextApplyDate ────────────────────────────────────────────────────────
+
+describe('calcNextApplyDate', () => {
+  describe('毎月', () => {
+    it('翌月の同日を返す', () => {
+      expect(calcNextApplyDate('2026-05-21', 'monthly', 21)).toBe('2026-06-21');
+    });
+
+    it('月をまたぐ場合に年が繰り上がる', () => {
+      // 2025-12-01 から毎月1日を進める: 2026-01→02→03→04→05→06-01(>今日5/21)
+      expect(calcNextApplyDate('2025-12-01', 'monthly', 1)).toBe('2026-06-01');
+    });
+
+    it('存在しない日は末日にクランプする（毎月31日 → 今日以降の最初の31日相当）', () => {
+      // 2026-01-31 から毎月31日: Feb→28, Mar→31, Apr→30, May→31(>今日5/21) で停止
+      expect(calcNextApplyDate('2026-01-31', 'monthly', 31)).toBe('2026-05-31');
+    });
+
+    it('複数期間前でも未来の日付まで正しく進める', () => {
+      // 3ヶ月前のエントリ → 6月21日が次回
+      const result = calcNextApplyDate('2026-02-21', 'monthly', 21);
+      const resultDate = new Date(result);
+      expect(resultDate > TODAY).toBe(true);
+      expect(result).toBe('2026-06-21');
+    });
+  });
+
+  describe('毎年', () => {
+    it('翌年の同日を返す', () => {
+      expect(calcNextApplyDate('2026-05-21', 'yearly', 21)).toBe('2027-05-21');
+    });
+
+    it('複数年前でも未来の日付まで正しく進める', () => {
+      const result = calcNextApplyDate('2024-03-01', 'yearly', 1);
+      const resultDate = new Date(result);
+      expect(resultDate > TODAY).toBe(true);
+      expect(result).toBe('2027-03-01');
+    });
+
+    it('うるう年の2月29日は平年には2月28日にクランプする', () => {
+      // 今日は2026-05-21。2024/2025/2026の2月はすでに過ぎているので2027-02-28
+      expect(calcNextApplyDate('2024-02-29', 'yearly', 29)).toBe('2027-02-28');
+    });
+  });
+});
+
+// ─── calcInitialNextApplyDate ─────────────────────────────────────────────────
+
+describe('calcInitialNextApplyDate', () => {
+  describe('毎月', () => {
+    it('指定日が今日より後なら今月の日付を返す', () => {
+      // 今日は21日、22日なら今月
+      expect(calcInitialNextApplyDate('monthly', 22, null)).toBe('2026-05-22');
+    });
+
+    it('指定日が今日と同じなら翌月を返す', () => {
+      // 今日は21日、21日なら翌月
+      expect(calcInitialNextApplyDate('monthly', 21, null)).toBe('2026-06-21');
+    });
+
+    it('指定日が今日より前なら翌月を返す', () => {
+      // 今日は21日、10日なら翌月
+      expect(calcInitialNextApplyDate('monthly', 10, null)).toBe('2026-06-10');
+    });
+
+    it('今月に存在する日は今月を返す', () => {
+      // 今日は5月21日。31日はまだ先(21 < 31) → 今月の5月31日
+      expect(calcInitialNextApplyDate('monthly', 31, null)).toBe('2026-05-31');
+    });
+  });
+
+  describe('毎年', () => {
+    it('今年の指定日がまだ来ていない場合は今年を返す', () => {
+      // 今日は5月21日、6月1日はまだ先
+      expect(calcInitialNextApplyDate('yearly', 1, 6)).toBe('2026-06-01');
+    });
+
+    it('今年の指定日が今日と同じ場合は来年を返す', () => {
+      expect(calcInitialNextApplyDate('yearly', 21, 5)).toBe('2027-05-21');
+    });
+
+    it('今年の指定日がすでに過ぎた場合は来年を返す', () => {
+      // 今日は5月21日、3月1日はすでに過ぎている
+      expect(calcInitialNextApplyDate('yearly', 1, 3)).toBe('2027-03-01');
+    });
+
+    it('month_of_yearがnullの場合は1月として扱う', () => {
+      // 今日は5月21日、1月はすでに過ぎているので来年1月
+      expect(calcInitialNextApplyDate('yearly', 15, null)).toBe('2027-01-15');
+    });
+  });
+});

--- a/app/api/recurring/apply/route.ts
+++ b/app/api/recurring/apply/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { requireAuth } from '@/lib/apiHelpers';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { calcNextApplyDate } from '@/lib/recurringUtils';
+import { logger } from '@/lib/logger';
+
+export async function POST(): Promise<NextResponse> {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { user, supabase } = auth;
+
+  try {
+    const today = new Date().toISOString().slice(0, 10);
+
+    // 今日以前に適用日が来ている有効なエントリを取得
+    const { data: dues, error: fetchError } = await supabase
+      .from('recurring_entries')
+      .select('*')
+      .eq('is_active', true)
+      .lte('next_apply_date', today);
+
+    if (fetchError) throw fetchError;
+    if (!dues || dues.length === 0) {
+      return NextResponse.json({ applied: 0 }, { status: 200 });
+    }
+
+    const { data: membership } = await supabase
+      .from('household_members')
+      .select('household_id')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    let applied = 0;
+
+    for (const entry of dues) {
+      const table = entry.type as 'income' | 'expense';
+
+      // 未分類フォールバック
+      let subcategoryId = entry.subcategory_id;
+      if (!subcategoryId) {
+        const { data: miscCat } = await supabaseAdmin
+          .from('categories')
+          .select('id')
+          .eq('name', '未分類').eq('type', table).is('user_id', null)
+          .maybeSingle();
+        if (miscCat) {
+          const { data: miscSub } = await supabaseAdmin
+            .from('subcategories')
+            .select('id')
+            .eq('category_id', miscCat.id).eq('name', '未分類').is('user_id', null)
+            .maybeSingle();
+          subcategoryId = miscSub?.id ?? null;
+        }
+      }
+
+      // エントリを挿入
+      const { error: insertError } = await supabase
+        .from(table)
+        .insert([{
+          source: entry.source,
+          amount: entry.amount,
+          subcategory_id: subcategoryId,
+          entry_date: entry.next_apply_date,
+          owner: entry.owner,
+          needs_settlement: entry.needs_settlement,
+          user_id: user.id,
+          household_id: membership?.household_id ?? null,
+        }]);
+
+      if (insertError) {
+        logger.error('繰り返しエントリの適用に失敗', { error: insertError, entryId: entry.id });
+        continue;
+      }
+
+      // 次回適用日を更新
+      const nextDate = calcNextApplyDate(entry.next_apply_date, entry.frequency, entry.day_of_month);
+      await supabase
+        .from('recurring_entries')
+        .update({ next_apply_date: nextDate })
+        .eq('id', entry.id);
+
+      applied += 1;
+    }
+
+    return NextResponse.json({ applied }, { status: 200 });
+  } catch (error) {
+    logger.error('POST recurring/apply error', { error });
+    return NextResponse.json({ error: '適用に失敗しました' }, { status: 500 });
+  }
+}

--- a/app/api/recurring/apply/route.ts
+++ b/app/api/recurring/apply/route.ts
@@ -24,6 +24,26 @@ export async function POST(): Promise<NextResponse> {
       return NextResponse.json({ applied: 0 }, { status: 200 });
     }
 
+    // 未分類IDをループ外で一度だけ取得（N+1回避）
+    const miscSubIds: Record<string, string | null> = {};
+    for (const type of ['income', 'expense'] as const) {
+      const { data: miscCat } = await supabaseAdmin
+        .from('categories')
+        .select('id')
+        .eq('name', '未分類').eq('type', type).is('user_id', null)
+        .maybeSingle();
+      if (miscCat) {
+        const { data: miscSub } = await supabaseAdmin
+          .from('subcategories')
+          .select('id')
+          .eq('category_id', miscCat.id).eq('name', '未分類').is('user_id', null)
+          .maybeSingle();
+        miscSubIds[type] = miscSub?.id ?? null;
+      } else {
+        miscSubIds[type] = null;
+      }
+    }
+
     const { data: membership } = await supabase
       .from('household_members')
       .select('household_id')
@@ -34,26 +54,28 @@ export async function POST(): Promise<NextResponse> {
 
     for (const entry of dues) {
       const table = entry.type as 'income' | 'expense';
+      const nextDate = calcNextApplyDate(entry.next_apply_date, entry.frequency, entry.day_of_month);
 
-      // 未分類フォールバック
-      let subcategoryId = entry.subcategory_id;
-      if (!subcategoryId) {
-        const { data: miscCat } = await supabaseAdmin
-          .from('categories')
-          .select('id')
-          .eq('name', '未分類').eq('type', table).is('user_id', null)
-          .maybeSingle();
-        if (miscCat) {
-          const { data: miscSub } = await supabaseAdmin
-            .from('subcategories')
-            .select('id')
-            .eq('category_id', miscCat.id).eq('name', '未分類').is('user_id', null)
-            .maybeSingle();
-          subcategoryId = miscSub?.id ?? null;
-        }
+      // next_apply_dateを先にアトミックに更新してクレームする（楽観的ロック）
+      // 別リクエストが先に更新済みの場合は0件が返り、このエントリをスキップする
+      const { data: claimed, error: claimError } = await supabase
+        .from('recurring_entries')
+        .update({ next_apply_date: nextDate })
+        .eq('id', entry.id)
+        .eq('next_apply_date', entry.next_apply_date)
+        .select('id');
+
+      if (claimError) {
+        logger.error('繰り返しエントリのクレームに失敗', { error: claimError, entryId: entry.id });
+        continue;
+      }
+      if (!claimed || claimed.length === 0) {
+        // 別リクエストがすでにクレーム済み → スキップ
+        continue;
       }
 
-      // エントリを挿入
+      // クレーム成功後にエントリを挿入
+      const subcategoryId = entry.subcategory_id ?? miscSubIds[table] ?? null;
       const { error: insertError } = await supabase
         .from(table)
         .insert([{
@@ -68,16 +90,9 @@ export async function POST(): Promise<NextResponse> {
         }]);
 
       if (insertError) {
-        logger.error('繰り返しエントリの適用に失敗', { error: insertError, entryId: entry.id });
+        logger.error('繰り返しエントリの挿入に失敗', { error: insertError, entryId: entry.id });
         continue;
       }
-
-      // 次回適用日を更新
-      const nextDate = calcNextApplyDate(entry.next_apply_date, entry.frequency, entry.day_of_month);
-      await supabase
-        .from('recurring_entries')
-        .update({ next_apply_date: nextDate })
-        .eq('id', entry.id);
 
       applied += 1;
     }

--- a/app/api/recurring/route.ts
+++ b/app/api/recurring/route.ts
@@ -1,0 +1,153 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { requireAuth } from '@/lib/apiHelpers';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+import { RecurringCreateSchema, RecurringUpdateSchema, zodErrorToMessages } from '@/lib/validation';
+import { calcInitialNextApplyDate } from '@/lib/recurringUtils';
+import { logger } from '@/lib/logger';
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { supabase } = auth;
+
+  try {
+    const onlyActive = new URL(req.url).searchParams.get('active') === '1';
+    let query = supabase
+      .from('recurring_entries')
+      .select('*, subcategory:subcategory_id(name, category:category_id(name))')
+      .order('created_at', { ascending: false });
+
+    if (onlyActive) query = query.eq('is_active', true);
+
+    const { data, error } = await query;
+    if (error) throw error;
+    return NextResponse.json({ data }, { status: 200 });
+  } catch (error) {
+    logger.error('GET recurring error', { error });
+    return NextResponse.json({ error: 'データ取得に失敗しました' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { user, supabase } = auth;
+
+  try {
+    const json = await request.json();
+    const parsed = RecurringCreateSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'validation_error', issues: zodErrorToMessages(parsed.error) }, { status: 400 });
+    }
+
+    const { type, source, amount, owner, needs_settlement, frequency, day_of_month, month_of_year } = parsed.data;
+    let { subcategory_id } = parsed.data;
+
+    if (!subcategory_id) {
+      const { data: miscCat } = await supabaseAdmin
+        .from('categories')
+        .select('id')
+        .eq('name', '未分類').eq('type', type).is('user_id', null)
+        .maybeSingle();
+      if (miscCat) {
+        const { data: miscSub } = await supabaseAdmin
+          .from('subcategories')
+          .select('id')
+          .eq('category_id', miscCat.id).eq('name', '未分類').is('user_id', null)
+          .maybeSingle();
+        subcategory_id = miscSub?.id ?? undefined;
+      }
+    }
+
+    const { data: membership } = await supabase
+      .from('household_members')
+      .select('household_id')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    const next_apply_date = calcInitialNextApplyDate(frequency, day_of_month, month_of_year ?? null);
+
+    const { data, error } = await supabase
+      .from('recurring_entries')
+      .insert([{
+        user_id: user.id,
+        household_id: membership?.household_id ?? null,
+        type, source, amount,
+        subcategory_id: subcategory_id ?? null,
+        owner, needs_settlement,
+        frequency, day_of_month,
+        month_of_year: month_of_year ?? null,
+        next_apply_date,
+      }])
+      .select();
+
+    if (error) throw error;
+    return NextResponse.json({ message: '作成OK', data }, { status: 200 });
+  } catch (error) {
+    logger.error('POST recurring error', { error });
+    return NextResponse.json({ error: '作成に失敗しました' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request): Promise<NextResponse> {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { supabase } = auth;
+
+  try {
+    const json = await request.json();
+    const parsed = RecurringUpdateSchema.safeParse(json);
+    if (!parsed.success) {
+      return NextResponse.json({ error: 'validation_error', issues: zodErrorToMessages(parsed.error) }, { status: 400 });
+    }
+    const { id, ...rest } = parsed.data;
+
+    // 頻度や日付が変わった場合は次回適用日を再計算
+    if (rest.frequency || rest.day_of_month) {
+      const { data: existing } = await supabase
+        .from('recurring_entries')
+        .select('frequency, day_of_month, month_of_year, next_apply_date')
+        .eq('id', id)
+        .single();
+
+      if (existing) {
+        const frequency = (rest.frequency ?? existing.frequency) as 'monthly' | 'yearly';
+        const dayOfMonth = rest.day_of_month ?? existing.day_of_month;
+        const monthOfYear = rest.month_of_year !== undefined ? rest.month_of_year : existing.month_of_year;
+        (rest as Record<string, unknown>).next_apply_date = calcInitialNextApplyDate(frequency, dayOfMonth, monthOfYear);
+      }
+    }
+
+    const { data, error } = await supabase
+      .from('recurring_entries')
+      .update(rest)
+      .eq('id', id)
+      .select();
+
+    if (error) throw error;
+    return NextResponse.json({ message: '更新OK', data }, { status: 200 });
+  } catch (error) {
+    logger.error('PATCH recurring error', { error });
+    return NextResponse.json({ error: '更新に失敗しました' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest): Promise<NextResponse> {
+  const auth = await requireAuth();
+  if (auth.errorResponse) return auth.errorResponse;
+  const { supabase } = auth;
+
+  try {
+    const idParam = new URL(request.url).searchParams.get('id');
+    const id = idParam ? Number(idParam) : NaN;
+    if (!Number.isFinite(id)) return NextResponse.json({ error: 'id が必要です' }, { status: 400 });
+
+    const { error } = await supabase.from('recurring_entries').delete().eq('id', id);
+    if (error) throw error;
+    return NextResponse.json({ message: '削除OK' }, { status: 200 });
+  } catch (error) {
+    logger.error('DELETE recurring error', { error });
+    return NextResponse.json({ error: '削除に失敗しました' }, { status: 500 });
+  }
+}

--- a/app/expense/page.tsx
+++ b/app/expense/page.tsx
@@ -61,7 +61,10 @@ export default function ExpensePage() {
   };
 
   useEffect(() => {
-    void load();
+    // 繰り返しエントリを適用してからデータを取得
+    fetch('/api/recurring/apply', { method: 'POST' })
+      .then(() => load())
+      .catch(() => load());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [q, month, offset]);
 

--- a/app/income/page.tsx
+++ b/app/income/page.tsx
@@ -60,7 +60,10 @@ export default function IncomePage() {
   };
 
   useEffect(() => {
-    void load();
+    // 繰り返しエントリを適用してからデータを取得
+    fetch('/api/recurring/apply', { method: 'POST' })
+      .then(() => load())
+      .catch(() => load());
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [q, month, offset]);
 

--- a/app/page.js
+++ b/app/page.js
@@ -129,6 +129,16 @@ export default async function Home({ searchParams }) {
           </div>
         </Link>
         <Link
+          href="/recurring"
+          className="bg-gray-800 rounded-xl p-4 flex items-center gap-3 hover:bg-gray-700 transition-colors"
+        >
+          <span className="text-2xl">🔁</span>
+          <div>
+            <p className="font-semibold">繰り返し</p>
+            <p className="text-xs text-gray-400">定期収支を自動登録</p>
+          </div>
+        </Link>
+        <Link
           href="/settings"
           className="bg-gray-800 rounded-xl p-4 flex items-center gap-3 hover:bg-gray-700 transition-colors"
         >

--- a/app/recurring/page.tsx
+++ b/app/recurring/page.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { readApiError } from '@/lib/ui/readApiError';
+import RecurringEntryModal, { type RecurringEntry } from '@/components/RecurringEntryModal';
+
+type RecurringRow = RecurringEntry & {
+  id: number;
+  next_apply_date: string;
+  is_active: boolean;
+  subcategory?: { name: string; category?: { name: string } | null } | null;
+};
+
+export default function RecurringPage() {
+  const [entries, setEntries] = useState<RecurringRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errMsg, setErrMsg] = useState('');
+  const [modalOpen, setModalOpen] = useState(false);
+  const [editItem, setEditItem] = useState<RecurringRow | null>(null);
+  const [modalErr, setModalErr] = useState('');
+
+  const load = async () => {
+    setLoading(true);
+    setErrMsg('');
+    try {
+      const res = await fetch('/api/recurring', { cache: 'no-store' });
+      if (!res.ok) { setErrMsg(await readApiError(res) || `HTTP ${res.status}`); return; }
+      const json = await res.json() as { data?: RecurringRow[] };
+      setEntries(Array.isArray(json.data) ? json.data : []);
+    } catch {
+      setErrMsg('データ取得に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { void load(); }, []);
+
+  const handleSave = async (payload: RecurringEntry & { amount: number }) => {
+    try {
+      const method = payload.id ? 'PATCH' : 'POST';
+      const res = await fetch('/api/recurring', {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) { setModalErr(await readApiError(res)); return; }
+      setModalOpen(false);
+      setEditItem(null);
+      await load();
+    } catch {
+      setModalErr(payload.id ? '更新に失敗しました' : '保存に失敗しました');
+    }
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('削除しますか？')) return;
+    try {
+      const res = await fetch(`/api/recurring?id=${id}`, { method: 'DELETE' });
+      if (!res.ok) { setErrMsg(await readApiError(res)); return; }
+      await load();
+    } catch {
+      setErrMsg('削除に失敗しました');
+    }
+  };
+
+  const handleToggleActive = async (row: RecurringRow) => {
+    try {
+      const res = await fetch('/api/recurring', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ id: row.id, is_active: !row.is_active }),
+      });
+      if (!res.ok) { setErrMsg(await readApiError(res)); return; }
+      await load();
+    } catch {
+      setErrMsg('更新に失敗しました');
+    }
+  };
+
+  const freqLabel = (row: RecurringRow) => {
+    if (row.frequency === 'monthly') return `毎月 ${row.day_of_month}日`;
+    return `毎年 ${row.month_of_year}月 ${row.day_of_month}日`;
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-900 text-white p-4">
+      <Link href="/" className="inline-block mb-4 text-sm text-gray-400 hover:text-white">← ホームに戻る</Link>
+      <h1 className="text-2xl font-bold mb-4">繰り返しエントリ</h1>
+
+      <div className="mb-6">
+        <button type="button"
+          onClick={() => { setEditItem(null); setModalErr(''); setModalOpen(true); }}
+          className="rounded bg-blue-700 px-4 py-2 text-white hover:bg-blue-800">
+          新規追加
+        </button>
+      </div>
+
+      {errMsg && <p className="mb-4 text-red-400">{errMsg}</p>}
+
+      {loading ? (
+        <p className="text-gray-400">読み込み中...</p>
+      ) : entries.length === 0 ? (
+        <p className="text-gray-400">繰り返しエントリがありません。</p>
+      ) : (
+        <ul className="space-y-2">
+          {entries.map((row) => (
+            <li key={row.id} className={`bg-gray-800 rounded p-4 ${!row.is_active ? 'opacity-50' : ''}`}>
+              <div className="flex justify-between items-start gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                      row.type === 'income' ? 'bg-green-800 text-green-200' : 'bg-red-900 text-red-200'
+                    }`}>
+                      {row.type === 'income' ? '収入' : '支出'}
+                    </span>
+                    <h3 className="font-bold text-white">{row.source}</h3>
+                    {!row.is_active && <span className="text-xs text-gray-500">（停止中）</span>}
+                  </div>
+                  <p className="text-xl font-semibold mt-1">{Number(row.amount).toLocaleString()}円</p>
+                  <p className="text-sm text-gray-400 mt-1">
+                    {freqLabel(row)}
+                    <span className="ml-3">次回: {row.next_apply_date}</span>
+                  </p>
+                  <p className="text-sm text-gray-400">
+                    カテゴリ: {row.subcategory
+                      ? (row.subcategory.category ? `${row.subcategory.category.name} › ${row.subcategory.name}` : row.subcategory.name)
+                      : '未分類'}
+                  </p>
+                  <div className="mt-1 flex gap-1">
+                    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${
+                      row.owner === 'shared' ? 'bg-purple-800 text-purple-200' : 'bg-gray-700 text-gray-300'
+                    }`}>
+                      {row.owner === 'shared' ? '家族共有' : '自分'}
+                    </span>
+                    {row.needs_settlement && (
+                      <span className="inline-block rounded-full bg-yellow-700 px-2 py-0.5 text-xs font-medium text-yellow-200">
+                        精算待ち
+                      </span>
+                    )}
+                  </div>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <button onClick={() => handleToggleActive(row)}
+                    className={`rounded px-3 py-1 text-sm ${row.is_active ? 'bg-gray-600 hover:bg-gray-500' : 'bg-blue-800 hover:bg-blue-700'}`}>
+                    {row.is_active ? '停止' : '有効化'}
+                  </button>
+                  <button onClick={() => { setEditItem(row); setModalErr(''); setModalOpen(true); }}
+                    className="rounded bg-yellow-600 px-3 py-1 text-sm hover:bg-yellow-500">
+                    編集
+                  </button>
+                  <button onClick={() => handleDelete(row.id)}
+                    className="rounded bg-red-600 px-3 py-1 text-sm hover:bg-red-500">
+                    削除
+                  </button>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <RecurringEntryModal
+        open={modalOpen}
+        title={editItem ? '繰り返しエントリを編集' : '繰り返しエントリを追加'}
+        initial={editItem}
+        onClose={() => { setModalOpen(false); setEditItem(null); }}
+        onSave={handleSave}
+        error={modalErr}
+        setError={setModalErr}
+      />
+    </div>
+  );
+}

--- a/src/components/RecurringEntryModal.tsx
+++ b/src/components/RecurringEntryModal.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Modal from './Modal';
+import CategorySelect from './CategorySelect';
+
+export type RecurringEntry = {
+  id?: number;
+  type: 'income' | 'expense';
+  source: string;
+  amount: number | string;
+  subcategory_id?: string | null;
+  owner?: 'self' | 'shared';
+  needs_settlement?: boolean;
+  frequency: 'monthly' | 'yearly';
+  day_of_month: number;
+  month_of_year?: number | null;
+  is_active?: boolean;
+};
+
+type SavePayload = Omit<RecurringEntry, 'amount'> & { amount: number };
+
+type Props = {
+  open: boolean;
+  title?: string;
+  initial: RecurringEntry | null;
+  onClose: () => void;
+  onSave: (payload: SavePayload) => Promise<void>;
+  error?: string;
+  setError?: (msg: string) => void;
+};
+
+export default function RecurringEntryModal({ open, title, initial, onClose, onSave, error, setError }: Props) {
+  const [type, setType] = useState<'income' | 'expense'>('expense');
+  const [source, setSource] = useState('');
+  const [amount, setAmount] = useState('');
+  const [subcategoryId, setSubcategoryId] = useState('');
+  const [owner, setOwner] = useState<'self' | 'shared'>('self');
+  const [needsSettlement, setNeedsSettlement] = useState(false);
+  const [frequency, setFrequency] = useState<'monthly' | 'yearly'>('monthly');
+  const [dayOfMonth, setDayOfMonth] = useState(1);
+  const [monthOfYear, setMonthOfYear] = useState(1);
+
+  useEffect(() => {
+    if (initial) {
+      setType(initial.type);
+      setSource(initial.source ?? '');
+      setAmount(String(initial.amount ?? ''));
+      setSubcategoryId(initial.subcategory_id ?? '');
+      setOwner(initial.owner ?? 'self');
+      setNeedsSettlement(initial.needs_settlement ?? false);
+      setFrequency(initial.frequency ?? 'monthly');
+      setDayOfMonth(initial.day_of_month ?? 1);
+      setMonthOfYear(initial.month_of_year ?? 1);
+    } else {
+      setType('expense');
+      setSource('');
+      setAmount('');
+      setSubcategoryId('');
+      setOwner('self');
+      setNeedsSettlement(false);
+      setFrequency('monthly');
+      setDayOfMonth(1);
+      setMonthOfYear(1);
+    }
+  }, [initial, open]);
+
+  const handleOwnerChange = (v: 'self' | 'shared') => {
+    setOwner(v);
+    if (v === 'self') setNeedsSettlement(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError?.('');
+    const n = Number(amount);
+    if (!source.trim()) { setError?.('内容は必須です'); return; }
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+      setError?.('金額は0以上の整数で入力してください'); return;
+    }
+    if (dayOfMonth < 1 || dayOfMonth > 31) {
+      setError?.('日は1〜31の範囲で入力してください'); return;
+    }
+    if (frequency === 'yearly' && (monthOfYear < 1 || monthOfYear > 12)) {
+      setError?.('月は1〜12の範囲で入力してください'); return;
+    }
+
+    await onSave({
+      id: initial?.id,
+      type,
+      source: source.trim(),
+      amount: n,
+      subcategory_id: subcategoryId || null,
+      owner,
+      needs_settlement: owner === 'shared' ? needsSettlement : false,
+      frequency,
+      day_of_month: dayOfMonth,
+      month_of_year: frequency === 'yearly' ? monthOfYear : null,
+    });
+  };
+
+  const settlementDisabled = owner === 'self';
+
+  return (
+    <Modal open={open} onClose={onClose} title={title ?? '繰り返しエントリを編集'}>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* 種別 */}
+        {!initial?.id && (
+          <div className="flex flex-col gap-1">
+            <label className="text-sm text-gray-300">種別</label>
+            <div className="flex gap-3">
+              {(['income', 'expense'] as const).map((v) => (
+                <button key={v} type="button" onClick={() => setType(v)}
+                  className={`rounded px-4 py-2 text-sm font-medium transition-colors ${
+                    type === v ? 'bg-blue-700 text-white' : 'border border-gray-500 text-gray-300 hover:bg-gray-700'
+                  }`}>
+                  {v === 'income' ? '収入' : '支出'}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* 内容 */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm text-gray-300">内容</label>
+          <input type="text" value={source} onChange={(e) => setSource(e.target.value)}
+            className="rounded border border-gray-600 bg-gray-800 p-2 text-white placeholder-gray-400"
+            placeholder="例：家賃、給与" />
+        </div>
+
+        {/* 金額 */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm text-gray-300">金額</label>
+          <input type="number" value={amount} onChange={(e) => setAmount(e.target.value)}
+            className="rounded border border-gray-600 bg-gray-800 p-2 text-white placeholder-gray-400"
+            placeholder="金額（円）" />
+        </div>
+
+        {/* カテゴリ */}
+        <CategorySelect type={type} value={subcategoryId} onChange={setSubcategoryId} />
+
+        {/* 繰り返し頻度 */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm text-gray-300">繰り返し</label>
+          <div className="flex gap-3">
+            {(['monthly', 'yearly'] as const).map((v) => (
+              <button key={v} type="button" onClick={() => setFrequency(v)}
+                className={`rounded px-4 py-2 text-sm font-medium transition-colors ${
+                  frequency === v ? 'bg-blue-700 text-white' : 'border border-gray-500 text-gray-300 hover:bg-gray-700'
+                }`}>
+                {v === 'monthly' ? '毎月' : '毎年'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 日付指定 */}
+        <div className="flex gap-3">
+          {frequency === 'yearly' && (
+            <div className="flex flex-col gap-1">
+              <label className="text-sm text-gray-300">月</label>
+              <input type="number" min={1} max={12} value={monthOfYear}
+                onChange={(e) => setMonthOfYear(Number(e.target.value))}
+                className="w-20 rounded border border-gray-600 bg-gray-800 p-2 text-white" />
+            </div>
+          )}
+          <div className="flex flex-col gap-1">
+            <label className="text-sm text-gray-300">日</label>
+            <input type="number" min={1} max={31} value={dayOfMonth}
+              onChange={(e) => setDayOfMonth(Number(e.target.value))}
+              className="w-20 rounded border border-gray-600 bg-gray-800 p-2 text-white" />
+          </div>
+          <div className="flex items-end pb-2 text-sm text-gray-400">
+            {frequency === 'yearly' ? `毎年 ${monthOfYear}月 ${dayOfMonth}日` : `毎月 ${dayOfMonth}日`}
+          </div>
+        </div>
+
+        {/* 帰属 */}
+        <div className="flex flex-col gap-1">
+          <label className="text-sm text-gray-300">帰属</label>
+          <div className="flex gap-3">
+            {(['self', 'shared'] as const).map((v) => (
+              <button key={v} type="button" onClick={() => handleOwnerChange(v)}
+                className={`rounded px-4 py-2 text-sm font-medium transition-colors ${
+                  owner === v ? 'bg-blue-700 text-white' : 'border border-gray-500 text-gray-300 hover:bg-gray-700'
+                }`}>
+                {v === 'self' ? '自分' : '家族共有'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* 精算待ち */}
+        <div className="flex flex-col gap-1">
+          <label className={`flex items-center gap-2 text-sm ${settlementDisabled ? 'cursor-not-allowed opacity-40' : 'cursor-pointer'}`}>
+            <input type="checkbox" checked={settlementDisabled ? false : needsSettlement}
+              onChange={(e) => setNeedsSettlement(e.target.checked)}
+              disabled={settlementDisabled}
+              className="h-4 w-4 rounded border-gray-600 bg-gray-800 accent-blue-600" />
+            <span className="text-gray-300">精算待ち</span>
+            {settlementDisabled && <span className="text-xs text-gray-500">（家族共有のみ対象）</span>}
+          </label>
+        </div>
+
+        {error && <p className="whitespace-pre-line text-red-400">{error}</p>}
+
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose}
+            className="rounded border border-gray-500 px-4 py-2 hover:bg-gray-800">
+            キャンセル
+          </button>
+          <button type="submit"
+            className="rounded bg-blue-700 px-4 py-2 text-white hover:bg-blue-800">
+            保存
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/src/lib/recurringUtils.ts
+++ b/src/lib/recurringUtils.ts
@@ -1,0 +1,68 @@
+/** 繰り返しエントリの次回適用日を計算する（今日より未来になるまで進める） */
+export function calcNextApplyDate(
+  currentDateStr: string,
+  frequency: 'monthly' | 'yearly',
+  dayOfMonth: number
+): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const [y, m, d] = currentDateStr.split('-').map(Number);
+  let current = new Date(y, m - 1, d);
+
+  while (current <= today) {
+    if (frequency === 'monthly') {
+      let nextMonth = current.getMonth() + 1;
+      let nextYear = current.getFullYear();
+      if (nextMonth > 11) { nextMonth = 0; nextYear += 1; }
+      const lastDay = new Date(nextYear, nextMonth + 1, 0).getDate();
+      current = new Date(nextYear, nextMonth, Math.min(dayOfMonth, lastDay));
+    } else {
+      const nextYear = current.getFullYear() + 1;
+      const month = current.getMonth();
+      const lastDay = new Date(nextYear, month + 1, 0).getDate();
+      current = new Date(nextYear, month, Math.min(dayOfMonth, lastDay));
+    }
+  }
+
+  return toDateStr(current);
+}
+
+/** 新規作成時の初回適用日を計算する */
+export function calcInitialNextApplyDate(
+  frequency: 'monthly' | 'yearly',
+  dayOfMonth: number,
+  monthOfYear: number | null | undefined
+): string {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const year = today.getFullYear();
+  const month = today.getMonth();
+  const todayDay = today.getDate();
+
+  if (frequency === 'monthly') {
+    let targetYear = year;
+    let targetMonth = month;
+    if (todayDay >= dayOfMonth) {
+      targetMonth += 1;
+      if (targetMonth > 11) { targetMonth = 0; targetYear += 1; }
+    }
+    const lastDay = new Date(targetYear, targetMonth + 1, 0).getDate();
+    return toDateStr(new Date(targetYear, targetMonth, Math.min(dayOfMonth, lastDay)));
+  } else {
+    const targetMonthIndex = (monthOfYear ?? 1) - 1;
+    const lastDayThisYear = new Date(year, targetMonthIndex + 1, 0).getDate();
+    const dayThisYear = Math.min(dayOfMonth, lastDayThisYear);
+    const thisYearDate = new Date(year, targetMonthIndex, dayThisYear);
+
+    if (thisYearDate > today) {
+      return toDateStr(thisYearDate);
+    }
+    const lastDayNextYear = new Date(year + 1, targetMonthIndex + 1, 0).getDate();
+    return toDateStr(new Date(year + 1, targetMonthIndex, Math.min(dayOfMonth, lastDayNextYear)));
+  }
+}
+
+function toDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}

--- a/src/lib/validation/index.ts
+++ b/src/lib/validation/index.ts
@@ -3,4 +3,5 @@ export * from './common';
 export * from './income';
 export * from './household';
 export * from './category';
+export * from './recurring';
 // expense 追加時はここに export * from './expense';

--- a/src/lib/validation/recurring.ts
+++ b/src/lib/validation/recurring.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+import { sourceSchema, amountSchema, ownerSchema, needsSettlementSchema } from './common';
+
+const subcategoryIdSchema = z.string().uuid({ message: '無効なカテゴリIDです' })
+  .optional()
+  .or(z.literal('').transform(() => undefined));
+
+export const RecurringCreateSchema = z.object({
+  type: z.enum(['income', 'expense'], { message: '種別はincomeまたはexpenseです' }),
+  source: sourceSchema,
+  amount: amountSchema,
+  subcategory_id: subcategoryIdSchema,
+  owner: ownerSchema.default('self'),
+  needs_settlement: needsSettlementSchema.default(false),
+  frequency: z.enum(['monthly', 'yearly'], { message: '頻度はmonthlyまたはyearlyです' }),
+  day_of_month: z.number({ message: '日は必須です' }).int().min(1).max(31, { message: '日は1〜31の範囲で入力してください' }),
+  month_of_year: z.number().int().min(1).max(12).optional().nullable(),
+}).refine(
+  (d) => d.frequency !== 'yearly' || (d.month_of_year != null),
+  { message: '毎年の場合は月を指定してください', path: ['month_of_year'] }
+);
+
+export const RecurringUpdateSchema = z.object({
+  id: z.number().int().positive(),
+  source: sourceSchema.optional(),
+  amount: amountSchema.optional(),
+  subcategory_id: subcategoryIdSchema,
+  owner: ownerSchema.optional(),
+  needs_settlement: needsSettlementSchema.optional(),
+  frequency: z.enum(['monthly', 'yearly']).optional(),
+  day_of_month: z.number().int().min(1).max(31).optional(),
+  month_of_year: z.number().int().min(1).max(12).optional().nullable(),
+  is_active: z.boolean().optional(),
+});

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -98,6 +98,63 @@ export type Database = {
           }
         ]
       }
+      recurring_entries: {
+        Row: {
+          id: number
+          user_id: string
+          household_id: string | null
+          type: string
+          source: string
+          amount: number
+          subcategory_id: string | null
+          owner: string
+          needs_settlement: boolean
+          frequency: string
+          day_of_month: number
+          month_of_year: number | null
+          next_apply_date: string
+          is_active: boolean
+          created_at: string
+          updated_at: string
+        }
+        Insert: {
+          id?: number
+          user_id: string
+          household_id?: string | null
+          type: string
+          source: string
+          amount: number
+          subcategory_id?: string | null
+          owner?: string
+          needs_settlement?: boolean
+          frequency: string
+          day_of_month: number
+          month_of_year?: number | null
+          next_apply_date: string
+          is_active?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Update: {
+          id?: number
+          user_id?: string
+          household_id?: string | null
+          type?: string
+          source?: string
+          amount?: number
+          subcategory_id?: string | null
+          owner?: string
+          needs_settlement?: boolean
+          frequency?: string
+          day_of_month?: number
+          month_of_year?: number | null
+          next_apply_date?: string
+          is_active?: boolean
+          created_at?: string
+          updated_at?: string
+        }
+        Relationships: []
+      }
       household_invitations: {
         Row: {
           created_at: string

--- a/supabase/migrations/20260517000000_add_recurring_entries.sql
+++ b/supabase/migrations/20260517000000_add_recurring_entries.sql
@@ -1,0 +1,41 @@
+-- 繰り返しエントリテーブル
+CREATE TABLE recurring_entries (
+  id              serial PRIMARY KEY,
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  household_id    uuid REFERENCES households(id) ON DELETE SET NULL,
+  type            text NOT NULL CHECK (type IN ('income', 'expense')),
+  source          text NOT NULL,
+  amount          bigint NOT NULL CHECK (amount >= 0),
+  subcategory_id  uuid REFERENCES subcategories(id) ON DELETE SET NULL,
+  owner           text NOT NULL DEFAULT 'self' CHECK (owner IN ('self', 'shared')),
+  needs_settlement boolean NOT NULL DEFAULT false,
+  frequency       text NOT NULL CHECK (frequency IN ('monthly', 'yearly')),
+  day_of_month    integer NOT NULL CHECK (day_of_month BETWEEN 1 AND 31),
+  month_of_year   integer CHECK (month_of_year BETWEEN 1 AND 12),
+  next_apply_date date NOT NULL,
+  is_active       boolean NOT NULL DEFAULT true,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE recurring_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "ユーザーは自分の繰り返しエントリを参照できる"
+  ON recurring_entries FOR SELECT
+  USING (user_id = auth.uid());
+
+CREATE POLICY "ユーザーは自分の繰り返しエントリを作成できる"
+  ON recurring_entries FOR INSERT
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "ユーザーは自分の繰り返しエントリを更新できる"
+  ON recurring_entries FOR UPDATE
+  USING (user_id = auth.uid());
+
+CREATE POLICY "ユーザーは自分の繰り返しエントリを削除できる"
+  ON recurring_entries FOR DELETE
+  USING (user_id = auth.uid());
+
+CREATE TRIGGER trg_recurring_entries_updated_at
+  BEFORE UPDATE ON recurring_entries
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary

- 毎月・毎年の定期収支を登録しておくと、収入/支出ページ表示時に自動でエントリが作成される
- `/recurring` ページで繰り返しエントリの一覧・作成・編集・削除・停止/有効化が可能
- `next_apply_date <= 今日` のエントリを `POST /api/recurring/apply` で一括適用し、次回適用日を自動更新

## Test plan

- [ ] `supabase db push` でマイグレーションを適用
- [ ] `/recurring` で繰り返しエントリ（毎月・毎年）を作成できる
- [ ] 収入または支出ページを開くと、期限切れの繰り返しエントリが自動適用される
- [ ] 適用後に `next_apply_date` が次回の日付に更新されている
- [ ] 停止中のエントリは適用されない
- [ ] ホームページに「繰り返し」のナビリンクが表示される

https://claude.ai/code/session_01KoHWjYqDCYhtXWLRkmrjMd

---
_Generated by [Claude Code](https://claude.ai/code/session_01KoHWjYqDCYhtXWLRkmrjMd)_